### PR TITLE
Make config use more explicit, not global

### DIFF
--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -4,6 +4,7 @@ import './cache'
 import './fly/cache'
 
 import { catalog, Context } from './'
+import { Config } from '../config';
 
 const errNoSuchBridgeFn = new Error("Attempted to call a unregistered bridge function.")
 
@@ -13,9 +14,10 @@ interface IterableIterator<T> extends Iterator<T> {
 
 export class Bridge {
   functions: Map<string, Function>
+  config: Config
 
-  constructor(ctx: Context) {
-    this.functions = new Map<string, Function>(Array.from(Array.from(catalog.entries()).map(([n, fn]) => [n, fn(ctx)])))
+  constructor(ctx: Context, config: Config) {
+    this.functions = new Map<string, Function>(Array.from(Array.from(catalog.entries()).map(([n, fn]) => [n, fn(ctx, config)])))
   }
 
   dispatch(name: string, ...args: any[]) {

--- a/src/bridge/fly/cache.ts
+++ b/src/bridge/fly/cache.ts
@@ -3,23 +3,21 @@ import { ivm } from '../../'
 import log from '../../log'
 import { Trace } from '../../trace'
 
-import { conf } from '../../config'
-
 const errCacheStoreUndefined = new Error("cacheStore is not defined in the config.")
 
 registerBridge('flyCacheSet', function (ctx: Context) {
   return function cacheSet(key: string, value: string, ttl: number, callback: ivm.Reference<Function>) {
     let k = "cache:" + ctx.meta.get('app').id + ":" + key
     let t = Trace.tryStart("cacheSet", ctx.trace)
-    console.log("native cache set:", k, "ttl:", ttl, "size:", value.length)
 
-    if (!conf.cacheStore)
+    if (!ctx.config.cacheStore)
       return callback.apply(null, [errCacheStoreUndefined.toString()])
 
-    conf.cacheStore.set(k, value, ttl).then((ok) => {
+    ctx.config.cacheStore.set(k, value, ttl).then((ok) => {
       t.end({ size: value.length, key: key })
       callback.apply(null, [null, ok])
     }).catch((err) => {
+      log.error(err)
       t.end()
       callback.apply(null, [err.toString()])
     })
@@ -30,12 +28,11 @@ registerBridge('flyCacheExpire', function (ctx: Context) {
   return function cacheExpire(key: string, ttl: number, callback: ivm.Reference<Function>) {
     let t = Trace.tryStart("cacheExpire", ctx.trace)
     let k = "cache:" + ctx.meta.get('app').id + ":" + key
-    console.log("native cache expire:", k, "ttl:", ttl)
 
-    if (!conf.cacheStore)
+    if (!ctx.config.cacheStore)
       return callback.apply(null, [errCacheStoreUndefined.toString()])
 
-    conf.cacheStore.expire(k, ttl).then((ok) => {
+    ctx.config.cacheStore.expire(k, ttl).then((ok) => {
       t.end({ key: key })
       callback.apply(null, [null, ok])
     }).catch((err) => {
@@ -49,12 +46,11 @@ registerBridge('flyCacheGetString', function (ctx: Context) {
   return function cacheGetString(key: string, callback: ivm.Reference<Function>) {
     let t = Trace.tryStart("cacheGet", ctx.trace)
     let k = "cache:" + ctx.meta.get('app').id + ":" + key
-    console.log("native cache get: " + k)
 
-    if (!conf.cacheStore)
+    if (!ctx.config.cacheStore)
       return callback.apply(null, [errCacheStoreUndefined.toString()])
-
-    conf.cacheStore.get(k).then((buf) => {
+  
+    ctx.config.cacheStore.get(k).then((buf) => {
       const size = buf ? buf.byteLength : 0
       const ret = buf ? buf.toString() : null
       t.end({ size: size, key: key })

--- a/src/bridge/fly/cache.ts
+++ b/src/bridge/fly/cache.ts
@@ -2,18 +2,19 @@ import { registerBridge, Context } from '../'
 import { ivm } from '../../'
 import log from '../../log'
 import { Trace } from '../../trace'
+import { Config } from '../../config';
 
 const errCacheStoreUndefined = new Error("cacheStore is not defined in the config.")
 
-registerBridge('flyCacheSet', function (ctx: Context) {
+registerBridge('flyCacheSet', function (ctx: Context, config: Config) {
   return function cacheSet(key: string, value: string, ttl: number, callback: ivm.Reference<Function>) {
     let k = "cache:" + ctx.meta.get('app').id + ":" + key
     let t = Trace.tryStart("cacheSet", ctx.trace)
 
-    if (!ctx.config.cacheStore)
+    if (!config.cacheStore)
       return callback.apply(null, [errCacheStoreUndefined.toString()])
 
-    ctx.config.cacheStore.set(k, value, ttl).then((ok) => {
+    config.cacheStore.set(k, value, ttl).then((ok) => {
       t.end({ size: value.length, key: key })
       callback.apply(null, [null, ok])
     }).catch((err) => {
@@ -24,15 +25,15 @@ registerBridge('flyCacheSet', function (ctx: Context) {
   }
 })
 
-registerBridge('flyCacheExpire', function (ctx: Context) {
+registerBridge('flyCacheExpire', function (ctx: Context, config: Config) {
   return function cacheExpire(key: string, ttl: number, callback: ivm.Reference<Function>) {
     let t = Trace.tryStart("cacheExpire", ctx.trace)
     let k = "cache:" + ctx.meta.get('app').id + ":" + key
 
-    if (!ctx.config.cacheStore)
+    if (!config.cacheStore)
       return callback.apply(null, [errCacheStoreUndefined.toString()])
 
-    ctx.config.cacheStore.expire(k, ttl).then((ok) => {
+    config.cacheStore.expire(k, ttl).then((ok) => {
       t.end({ key: key })
       callback.apply(null, [null, ok])
     }).catch((err) => {
@@ -42,15 +43,15 @@ registerBridge('flyCacheExpire', function (ctx: Context) {
   }
 })
 
-registerBridge('flyCacheGetString', function (ctx: Context) {
+registerBridge('flyCacheGetString', function (ctx: Context, config: Config) {
   return function cacheGetString(key: string, callback: ivm.Reference<Function>) {
     let t = Trace.tryStart("cacheGet", ctx.trace)
     let k = "cache:" + ctx.meta.get('app').id + ":" + key
 
-    if (!ctx.config.cacheStore)
+    if (!config.cacheStore)
       return callback.apply(null, [errCacheStoreUndefined.toString()])
   
-    ctx.config.cacheStore.get(k).then((buf) => {
+    config.cacheStore.get(k).then((buf) => {
       const size = buf ? buf.byteLength : 0
       const ret = buf ? buf.toString() : null
       t.end({ size: size, key: key })

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1,4 +1,5 @@
 import { Trace } from '../trace'
+import { Config } from '../config';
 export let catalog = new Map<string, BridgeFunctionFactory>()
 export function registerBridge(name: string, fn: BridgeFunctionFactory) {
   catalog.set(name, fn)
@@ -6,7 +7,8 @@ export function registerBridge(name: string, fn: BridgeFunctionFactory) {
 
 export interface Context {
   meta: Map<string, any>
-  trace: Trace | undefined
+  trace: Trace | undefined,
+  config: Config
 }
 
 export interface BridgeFunctionFactory {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -7,10 +7,9 @@ export function registerBridge(name: string, fn: BridgeFunctionFactory) {
 
 export interface Context {
   meta: Map<string, any>
-  trace: Trace | undefined,
-  config: Config
+  trace: Trace | undefined
 }
 
 export interface BridgeFunctionFactory {
-  (ctx: Context): Function
+  (ctx: Context, config: Config): Function
 }

--- a/src/cache_store.ts
+++ b/src/cache_store.ts
@@ -3,4 +3,5 @@ export interface CacheStore {
   set(key: string, value: any, ttl?: number): Promise<boolean>
   expire(key: string, ttl: number): Promise<boolean>
   ttl(key: string): Promise<number>
+  rand?: number
 }

--- a/src/caches/memory.ts
+++ b/src/caches/memory.ts
@@ -6,8 +6,10 @@ const OK = 'ok'
 
 export class MemoryCacheStore implements CacheStore {
   redis: IORedis.Redis
-  constructor() {
+  rand: number
+  constructor(label?:string) {
     this.redis = new Redis()
+    this.rand = Math.random()
   }
 
   async get(key: string): Promise<Buffer> {

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -29,6 +29,7 @@ root
     const { FileStore } = require('../app/stores/file')
     const { getWebpackConfig, buildAppWithConfig } = require('../utils/build')
     const { createContext } = require('../context')
+    const { runtimeConfig } = require("../config")
 
     const cwd = process.cwd()
 
@@ -59,7 +60,7 @@ root
       try {
         await v8Env.waitForReadiness()
         const iso = new ivm.Isolate({ snapshot: v8Env.snapshot })
-        const ctx = await createContext(iso)
+        const ctx = await createContext(runtimeConfig, iso)
 
         const app = await appStore.getAppByHostname()
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export interface Config {
   contextStore?: ContextStore
 }
 
-export let conf: Config = parseConfig(process.cwd())
+export let runtimeConfig: Config = parseConfig(process.cwd())
 
 export function parseConfig(cwd: string): Config {
   const env = getValue(process.env.FLY_ENV, process.env.NODE_ENV, 'development')

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,18 +1,21 @@
 import { ivm } from './'
 import log from "./log"
-import { conf } from './config'
+//import { conf } from './config'
 import { Bridge } from './bridge/bridge'
 import { Trace } from './trace'
+import { Config } from './config';
 
 export class Context {
 	ctx: ivm.Context
 	trace: Trace | undefined
 	private global: ivm.Reference<Object>
 	meta: Map<string, any>
+	config: Config
 
-	constructor(ctx: ivm.Context) {
+	constructor(ctx: ivm.Context, config: Config) {
 		this.meta = new Map<string, any>()
 		this.ctx = ctx
+		this.config = config
 		this.global = ctx.globalReference()
 	}
 
@@ -20,7 +23,7 @@ export class Context {
 		await this.set('global', this.global.derefInto());
 		await this.set('_ivm', ivm);
 
-		if (conf.env !== 'production') {
+		if (this.config.env !== 'production') {
 			await this.set('_log', new ivm.Reference(function (lvl: string, ...args: any[]) {
 				log.log(lvl, args[0], ...args.slice(1))
 			}))
@@ -54,8 +57,8 @@ export class Context {
 	}
 }
 
-export async function createContext(iso: ivm.Isolate, opts: ivm.ContextOptions = {}): Promise<Context> {
-	let ctx = new Context(await iso.createContext(opts))
+export async function createContext(config: Config, iso: ivm.Isolate, opts: ivm.ContextOptions = {}): Promise<Context> {
+	let ctx = new Context(await iso.createContext(opts), config)
 	await ctx.bootstrap()
 	return ctx
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import { ivm } from './'
 import log from "./log"
-//import { conf } from './config'
+//import { conf } from './config'a
 import { Bridge } from './bridge/bridge'
 import { Trace } from './trace'
 import { Config } from './config';
@@ -55,7 +55,7 @@ export class Context {
 	}
 }
 
-export async function createContext(config: Config, iso: ivm.Isolate, opts: ivm.ContextOptions): Promise<Context> {
+export async function createContext(config: Config, iso: ivm.Isolate, opts: ivm.ContextOptions = {}): Promise<Context> {
 	let ctx = new Context(await iso.createContext(opts))
 	await ctx.bootstrap(config)
 	return ctx

--- a/src/context_store.ts
+++ b/src/context_store.ts
@@ -1,8 +1,9 @@
 import { App } from './app'
 import { Context } from './context'
 import { Trace } from './trace'
+import { Config } from './config'
 
 export interface ContextStore {
-  getContext(app: App, trace?: Trace): Promise<Context>
+  getContext(config:Config, app: App, trace?: Trace): Promise<Context>
   putContext(ctx: Context): void
 }

--- a/src/default_context_store.ts
+++ b/src/default_context_store.ts
@@ -7,6 +7,7 @@ import { Trace } from './trace'
 import { createContext } from './context'
 
 import { App } from './app'
+import { Config } from './config';
 
 export interface DefaultContextStoreOptions {
   inspect?: boolean
@@ -21,14 +22,14 @@ export class DefaultContextStore implements ContextStore {
     v8Env.on('snapshot', this.resetIsolate.bind(this))
   }
 
-  async getContext(app: App, trace?: Trace) {
+  async getContext(config: Config, app: App, trace?: Trace) {
     const t = trace || Trace.start("acquireContext")
     let t2 = t.start("getIsolate")
     const iso = await this.getIsolate()
     t2.end()
 
     t2 = t.start("createContext")
-    const ctx = await createContext(iso, { inspector: !!this.options.inspect })
+    const ctx = await createContext(config, iso, { inspector: !!this.options.inspect })
     t2.end()
 
     t2 = t.start("compile")

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,8 +1,8 @@
-import { conf } from './config'
+//import { conf } from './config'
 import * as winston from 'winston';
 
 export default new winston.Logger({
-  level: conf.logLevel,
+  //level: conf.logLevel,
   transports: [
     new winston.transports.Console({ timestamp: true }),
   ]

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,7 +185,7 @@ export class Server extends EventEmitter {
 				this.config.contextStore = new DefaultContextStore()
 
 			let t = trace.start("acquireContext")
-			let ctx = await this.config.contextStore.getContext(app, t)
+			let ctx = await this.config.contextStore.getContext(this.config, app, t)
 			t.end()
 			ctx.trace = trace
 

--- a/src/v8env.ts
+++ b/src/v8env.ts
@@ -1,4 +1,4 @@
-import { conf } from './config'
+import { runtimeConfig } from './config'
 
 import * as path from 'path'
 import * as fs from 'fs'
@@ -53,7 +53,7 @@ export class V8Environment extends EventEmitter {
   }
 
   startCodeUpdater() {
-    if (conf.env === 'development')
+    if (runtimeConfig.env === 'development')
       compiler.watch({}, this.updateV8Env.bind(this))
     else
       compiler.run(this.updateV8Env.bind(this))

--- a/test/fixtures/apps/fly-cache/index.js
+++ b/test/fixtures/apps/fly-cache/index.js
@@ -1,29 +1,26 @@
-addEventListener('fetch', function (event) {
-  event.respondWith(async function () {
-    console.log("cache-api mw:", event.request.url)
-    let body = await fly.cache.getString(event.request.url)
-    let ttl = parseInt(event.request.headers.get('ttl'))
+fly.http.respondWith(async function (request) {
+  let body = await fly.cache.getString(request.url)
+  let ttl = parseInt(request.headers.get('ttl'))
+  if (!isNaN(ttl)) {
+    ttl = ttl / 2 // we're going to run the expire command too
+  }
+  if (body == null) {
+    body = request.url
+    if (request.url.match(/\/cache-api\/yuge\//)) {
+      console.log("Setting a yuge cache value")
+      try {
+        await fly.cache.set(request.url, "☃".repeat(2.1 * 1024 * 1024), ttl)
+      } catch (err) {
+        console.log(err.toString(), "body:", body)
+        return new Response(err.toString(), { status: 500 })
+      }
+    } else {
+      await fly.cache.set(request.url, body, ttl)
+    }
     if (!isNaN(ttl)) {
-      ttl = ttl / 2 // we're going to run the expire command too
+      await fly.cache.expire(request.url, ttl * 2) // sets it back to the original value
     }
-    if (body == null) {
-      body = event.request.url
-      if (event.request.url.match(/\/cache-api\/yuge\//)) {
-        console.log("Setting a yuge cache value")
-        try {
-          await fly.cache.set(event.request.url, "☃".repeat(2.1 * 1024 * 1024), ttl)
-        } catch (err) {
-          console.log(err.toString(), "body:", body)
-          return new Response(err.toString(), { status: 500 })
-        }
-      } else {
-        await fly.cache.set(event.request.url, body, ttl)
-      }
-      if (!isNaN(ttl)) {
-        await fly.cache.expire(event.request.url, ttl * 2) // sets it back to the original value
-      }
-    }
+  }
 
-    return new Response(body, {})
-  })
+  return new Response(body, {})
 })

--- a/test/fly.cache.spec.ts
+++ b/test/fly.cache.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
-import { startServer } from './helper'
-import { conf } from '../src/config'
+import { startServer, cacheStore } from './helper'
 import axios from 'axios'
 
 describe('Cache API', () => {
@@ -16,7 +15,7 @@ describe('Cache API', () => {
 
     expect(res.status).to.equal(200)
 
-    let cached = await conf.cacheStore.get(`cache:test-app-id:${url}`)
+    let cached = await cacheStore.get(`cache:test-app-id:${url}`)
     expect(cached).to.equal(url)
   })
 
@@ -27,7 +26,7 @@ describe('Cache API', () => {
 
     expect(res.status).to.equal(200)
 
-    let ttl = await conf.cacheStore.ttl(`cache:test-app-id:${url}`)
+    let ttl = await cacheStore.ttl(`cache:test-app-id:${url}`)
     expect(ttl).to.equal(3600)
   })
 
@@ -40,7 +39,7 @@ describe('Cache API', () => {
 
   it('gets a value', async () => {
     let data = "cached:" + Math.random().toString()
-    await conf.cacheStore.set("cache:test-app-id:http://test/cache-api/get", data)
+    await cacheStore.set("cache:test-app-id:http://test/cache-api/get", data)
 
     let res = await axios.get("http://127.0.0.1:3333/cache-api/get", { headers: { 'Host': 'test' } })
     expect(res.status).to.equal(200)

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -18,17 +18,18 @@ import http = require('http')
 
 import { FileStore, FileStoreOptions } from '../src/app/stores/file'
 import { DefaultContextStore } from '../src/default_context_store';
+import { MemoryCacheStore } from '../src/caches/memory';
 
 const Replay = require('replay');
 Replay.fixtures = './test/fixtures/replay';
 Replay.headers.push(/^fly-/);
-
 
 export interface ServerOptions extends FileStoreOptions {
   port?: number
 }
 
 const contextStore = new DefaultContextStore()
+export const cacheStore = new MemoryCacheStore("test cache")
 
 export async function startServer(cwd: string, options?: ServerOptions): Promise<http.Server> {
   options || (options = {})
@@ -44,7 +45,7 @@ export async function startServer(cwd: string, options?: ServerOptions): Promise
 
   conf.appStore = appStore
 
-  const server = new Server(Object.assign({}, conf, { contextStore, appStore }))
+  const server = new Server(Object.assign({}, conf, { contextStore, appStore, cacheStore }))
   const http = server.server
 
   server.addListener("requestEnd", (req, res, trace) => {


### PR DESCRIPTION
This fixes #9. Config is now passed around as necessary, rather than being loaded from a global. The only global config is the one used for builds since there's no associated server/adapters.