### PR TITLE
feat: ProxyStreams

### DIFF
--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -1,3 +1,4 @@
+import './proxy_stream'
 import './fetch'
 import './formdata'
 import './fly/cache'

--- a/src/bridge/fetch.ts
+++ b/src/bridge/fetch.ts
@@ -7,6 +7,7 @@ import * as https from 'https'
 import { URL, parse as parseURL, format as formatURL } from 'url'
 import { headersForWeb, fullURL } from '../utils/http'
 import { transferInto } from '../utils/buffer'
+import { ProxyStream } from './proxy_stream'
 
 import { Trace } from '../trace'
 
@@ -75,29 +76,32 @@ export function fetchBridge(ctx: Context) {
               url: urlStr,
               headers: res.headers
             }),
-            new ivm.Reference(function (callback: ivm.Reference<Function>) {
-              setImmediate(async () => {
-                res.on("close", function () {
-                  t.end()
-                  callback.apply(undefined, ["close"])
-                })
-                res.on("end", function () {
-                  t.end()
-                  callback.apply(undefined, ["end"])
-                })
-                res.on("error", function (err: Error) {
-                  t.end()
-                  callback.apply(undefined, ["error", err.toString()])
-                })
-
-                res.on("data", function (data: Buffer) {
-                  callback.apply(undefined, ["data", transferInto(data)])
-                })
-                res.resume()
-                //callback.apply(undefined, ["end"])
-              })
-            }),
-            new ivm.Reference(res)
+            new ProxyStream(res).ref
+//            new ivm.Reference(function (callback: ivm.Reference<Function>) {
+//              setImmediate(async () => {
+//                res.on("close", function () {
+//                  t.end()
+//                  ctx.addCallback(callback)
+//                  ctx.applyCallback(callback, ["close"])
+//                })
+//                res.on("end", function () {
+//                  t.end()
+//                  ctx.addCallback(callback)
+//                  ctx.applyCallback(callback, ["end"])
+//                })
+//                res.on("error", function (err: Error) {
+//                  t.end()
+//                  ctx.addCallback(callback)
+//                  ctx.applyCallback(callback, ["error", err.toString()])
+//                })
+//
+//                res.on("data", function (data: Buffer) {
+//                  ctx.addCallback(callback)
+//                  ctx.applyCallback(callback, ["data", transferInto(data)])
+//                })
+//                res.resume()
+//              })
+//            }),
           ])
         })
 

--- a/src/bridge/proxy_stream.ts
+++ b/src/bridge/proxy_stream.ts
@@ -49,6 +49,6 @@ registerBridge("readProxyStream", function(ctx){
     stream.on("data", function (data: Buffer) {
       cb.apply(undefined, ["data", transferInto(data)])
     })
-    stream.resume()
+    setImmediate(()=> stream.resume())
   }
 })

--- a/src/bridge/proxy_stream.ts
+++ b/src/bridge/proxy_stream.ts
@@ -1,0 +1,54 @@
+import { registerBridge, Context } from './'
+import { Readable } from "stream";
+import { ivm } from "../";
+import { transferInto } from "../utils/buffer";
+
+// get stream from http or whatever
+// pass reference back to v8
+//   * v8 optionally reads stream
+// pass reference from v8 -> node
+//   * cache set
+//   * returned response
+// once stream is read, it's dirty
+//   * if we're only reading from within node, we should handle this
+//   * can pipe it to both cache and http response
+
+export class ProxyStream{
+  stream: Readable
+  private _ref:ivm.Reference<ProxyStream> | undefined
+
+  constructor(base:Readable){
+    this.stream = base
+  }
+
+  get ref(){
+    if(!this._ref){
+      this._ref = new ivm.Reference<ProxyStream>(this)
+    }
+    return this._ref
+  }
+}
+
+registerBridge("readProxyStream", function(ctx){
+  return function(ref: ivm.Reference<ProxyStream>, cb: ivm.Reference<Function>){
+    const proxyable = ref.deref()
+    const stream = proxyable.stream
+    if(!stream){
+      cb.apply(undefined, ["end"])
+      return
+    }
+    stream.on("close", function(){
+      cb.apply(undefined, ["close"])
+    })
+    stream.on("end", function () {
+      cb.apply(undefined, ["end"])
+    })
+    stream.on("error", function (err: Error) {
+      cb.apply(undefined, ["error", err.toString()])
+    })
+    stream.on("data", function (data: Buffer) {
+      cb.apply(undefined, ["data", transferInto(data)])
+    })
+    stream.resume()
+  }
+})

--- a/test/fixtures/apps/basic-fetch-and-read.js
+++ b/test/fixtures/apps/basic-fetch-and-read.js
@@ -1,0 +1,6 @@
+fly.http.respondWith(async function(req){
+  let resp = await fetch("https://example.com")
+  let txt = await resp.text()
+  console.log("Got text: ", txt.length)
+  return new Response(txt, resp)
+})

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -31,6 +31,21 @@ describe('Server', () => {
     })
   })
 
+  // same test as above, but reads fetch response into context
+  describe('basic fetch and read app', () => {
+    before(async function () {
+      this.server = await startServer("basic-fetch-and-read.js")
+    })
+    after(function (done) { this.server.close(done) })
+
+    it('may fetch responses externally', async () => {
+      let res = await axios.get("http://127.0.0.1:3333/", { headers: { host: "test" } })
+      expect(res.status).to.equal(200);
+      expect(res.data).to.include(`<title>Example Domain</title>`)
+      expect(res.headers['content-type']).to.equal('text/html')
+    })
+  })
+
   describe('basic transform app', () => {
     // before(async function () {
     //   this.server = await startServer("basic-transform.js")

--- a/v8env/events.js
+++ b/v8env/events.js
@@ -51,7 +51,7 @@ export class FetchEvent {
 					this.callback(err)
 				})
 			} else if (ret instanceof Response) {
-				this.callback(null, fn)
+				this.callback(null, ret)
 			} else {
 				this.callback(invalidResponseType)
 			}

--- a/v8env/fetch.js
+++ b/v8env/fetch.js
@@ -39,16 +39,18 @@ export default function fetchInit(ivm, dispatch) {
 				url,
 				new ivm.ExternalCopy(init).copyInto(),
 				transferInto(ivm, body),
-				new ivm.Reference(function (err, nodeRes, nodeBody, proxied) {
+				new ivm.Reference(function (err, nodeRes, nodeBody) {
 					if (err != null) {
 						logger.debug("err :(", err)
 						reject(err)
 						return
 					}
-					resolve(new Response(nodeBody, nodeRes.copy(), proxied))
+					resolve(new Response(nodeBody, nodeRes.copy()))
 				})
 			])
 			logger.debug("dispatched nativefetch")
 		})
 	}
+
+
 }

--- a/v8env/request.js
+++ b/v8env/request.js
@@ -30,9 +30,6 @@ export default function requestInit(ivm) {
 
 			logger.debug("ARG 2 IS:", arguments[2] instanceof ivm.Reference, arguments[2] && arguments[2].toString())
 
-			if (arguments[2] instanceof ivm.Reference) //proxied
-				this._proxy = arguments[2]
-
 			// logger.debug('creating request! body typeof:', typeof Body, typeof init.body)
 			Body.call(this, null);
 


### PR DESCRIPTION
Streams in responses / requests can be passed in and out of contexts by
reference, which limits memory use for typical proxy use cases:

```
fly.http.respondWith(function(req){
  // return without reading body
  return fetch("http://proxied-service/big-horkin-file")
});
```