### PR TITLE
Only pull config from `config:` namespace in .fly.yml

### DIFF
--- a/src/app/stores/file.ts
+++ b/src/app/stores/file.ts
@@ -58,7 +58,7 @@ export class FileStore implements AppStore {
           if (event === 'change') {
             console.log("Detected .fly.yml change, updating in-memory config.")
             try {
-              this.releaseInfo.config = getLocalConfig(cwd)
+              this.releaseInfo.config = getLocalConfig(cwd).config || {}
             } catch (e) {
               console.error(e)
             }


### PR DESCRIPTION
This matches the behavior of `fly deploy`, which only grabs `config:`
namespace.