### PR TITLE
Inject secrets on config reload

### DIFF
--- a/src/app/stores/file.ts
+++ b/src/app/stores/file.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import fs = require('fs-extra')
 
 import { buildApp } from '../../utils/build'
-import { getLocalConfig, getLocalSecrets } from '../config'
+import { getLocalConfig, getLocalSecrets, parseConfig } from '../config'
 
 import * as webpack from 'webpack'
 const MemoryFS = require('memory-fs')
@@ -49,6 +49,8 @@ export class FileStore implements AppStore {
     if (this.options.secrets)
       this.releaseInfo.secrets = this.options.secrets
 
+    parseConfig(this.releaseInfo.config, this.releaseInfo.secrets)
+
     const flyYmlPath = path.join(cwd, '.fly.yml')
     const flySecretsPath = path.join(cwd, '.fly.secrets.yml')
 
@@ -59,6 +61,7 @@ export class FileStore implements AppStore {
             console.log("Detected .fly.yml change, updating in-memory config.")
             try {
               this.releaseInfo.config = getLocalConfig(cwd).config || {}
+              parseConfig(this.releaseInfo.config, this.releaseInfo.secrets)
             } catch (e) {
               console.error(e)
             }
@@ -71,6 +74,7 @@ export class FileStore implements AppStore {
             console.log("Detected .fly.secrets.yml change, updating in-memory config.")
             try {
               this.releaseInfo.secrets = getLocalSecrets(cwd)
+              parseConfig(this.releaseInfo.config, this.releaseInfo.secrets)
             } catch (e) {
               console.error(e)
             }

--- a/test/app/stores/file.spec.ts
+++ b/test/app/stores/file.spec.ts
@@ -1,0 +1,36 @@
+import { expect, assert } from 'chai'
+import { FileStore } from '../../../src/app/stores/file'
+
+
+describe('FileStore', function() {
+  describe('initialize', () => {
+    it('throws error when bad working directory path is provided', async () => {
+      assert.throws(() => new FileStore("badpath"), Error, /Could not find path/)
+    })
+
+    it('throws error if no code detected', async () => {
+      assert.throws(() => new FileStore(__dirname), Error, /no code/)
+    })
+
+    // { noWatch: true } is needed to make sure tests exit
+    it('loads app with no config file', async () => {
+      let store = new FileStore(__dirname + '/testdata/no-config', { noWatch: true })
+      expect(store.releaseInfo.config).to.eql({})
+    })
+
+    it('loads app with config file', async () => {
+      let store = new FileStore(__dirname + '/testdata/config-no-secrets', { noWatch: true })
+      expect(store.releaseInfo.app_id).to.equal("config-no-secrets")
+    })
+
+    it('interpolates secrets correctly', async () => {
+      let store = new FileStore(__dirname + '/testdata/config-and-secrets', { noWatch: true })
+      expect(store.releaseInfo.app_id).to.equal("config-and-secrets")
+      expect(store.releaseInfo.config).to.eql({
+        "option_a": "val_a",
+        "password": "sekret"
+      })
+    })
+  })
+
+})

--- a/test/app/stores/testdata/config-and-secrets/.fly.secrets.yml
+++ b/test/app/stores/testdata/config-and-secrets/.fly.secrets.yml
@@ -1,0 +1,1 @@
+my_app_password: 'sekret'

--- a/test/app/stores/testdata/config-and-secrets/.fly.yml
+++ b/test/app/stores/testdata/config-and-secrets/.fly.yml
@@ -1,0 +1,5 @@
+app_id: config-and-secrets
+config:
+  option_a: val_a
+  password:
+    fromSecret: my_app_password

--- a/test/app/stores/testdata/config-and-secrets/index.js
+++ b/test/app/stores/testdata/config-and-secrets/index.js
@@ -1,0 +1,3 @@
+fly.http.respondWith(function(request) {
+  return new Response("hello")
+})

--- a/test/app/stores/testdata/config-no-secrets/.fly.yml
+++ b/test/app/stores/testdata/config-no-secrets/.fly.yml
@@ -1,0 +1,3 @@
+app_id: config-no-secrets
+config:
+  option_a: val_a

--- a/test/app/stores/testdata/config-no-secrets/index.js
+++ b/test/app/stores/testdata/config-no-secrets/index.js
@@ -1,0 +1,3 @@
+fly.http.respondWith(function(request) {
+  return new Response("hello")
+})

--- a/test/app/stores/testdata/no-config/index.js
+++ b/test/app/stores/testdata/no-config/index.js
@@ -1,0 +1,3 @@
+fly.http.respondWith(function(request) {
+  return new Response("hello")
+})


### PR DESCRIPTION
Currently, secrets get loaded from `.fly.secrets.yml` and then certain entries loaded in `.fly.yml` get substituted with those secrets. E.g.:

```
# .fly.yml

app_id: some-app
config:
  password:
    fromSecret: password_for_app
```

```
# fly.secrets.yml
password_for_app: 123456
```

The expectation is to have `app.config.password` return `123456`, however if .fly.yml is modified when `fly server` is running, then the new config is not processed and special `fromSecret` entries are not getting replaced with actual secrets.