### PR TITLE
feat(store): provide config environment as `app.env` during runtime

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,15 +8,18 @@ export interface ReleaseInfo {
   source_hash: string
   config: any
   secrets: any
+  env: string
 }
 
 export class App {
   id: string
+  env: string
   releaseInfo: ReleaseInfo
   private _config: any
 
   constructor(releaseInfo: ReleaseInfo) {
     this.id = releaseInfo.app_id
+    this.env = releaseInfo.env
     this.releaseInfo = releaseInfo
   }
 
@@ -43,7 +46,8 @@ export class App {
   forV8() {
     return new ivm.ExternalCopy({
       id: this.id,
-      config: this.config
+      config: this.config,
+      env: this.env
     }).copyInto({ release: true })
   }
 }

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -21,25 +21,3 @@ export function parseConfig(config: any, secrets: any) {
     }
   }
 }
-
-export function getLocalSecrets(cwd = process.cwd()) {
-  const localSecretsPath = path.join(cwd, ".fly.secrets.yml")
-  let secrets = {};
-
-  if (fs.existsSync(localSecretsPath))
-    secrets = YAML.load(fs.readFileSync(localSecretsPath).toString())
-
-  return secrets
-}
-
-export function getLocalConfig(
-  cwd = process.cwd(),
-  env = process.env.FLY_ENV || process.env.NODE_ENV || 'development'
-) {
-  const localConfigPath = path.join(cwd, ".fly.yml")
-  let config: any = {};
-  if (fs.existsSync(localConfigPath))
-    config = YAML.load(fs.readFileSync(localConfigPath).toString())
-
-  return config[env] || config
-}

--- a/src/app/stores/file.ts
+++ b/src/app/stores/file.ts
@@ -1,14 +1,15 @@
 import { AppStore } from '../store'
 import { App, ReleaseInfo } from '../../app'
 import * as path from 'path'
-import fs = require('fs-extra')
+import * as fs from 'fs-extra'
+import * as YAML from 'js-yaml'
 
 import { buildApp } from '../../utils/build'
-import { getLocalConfig, getLocalSecrets, parseConfig } from '../config'
+import { parseConfig } from '../config'
+import { getLocalConfig, getLocalSecrets, getEnv } from './utils'
 
 import * as webpack from 'webpack'
-const MemoryFS = require('memory-fs')
-const importCwd = require('import-cwd')
+
 
 export interface FileStoreOptions {
   build?: boolean
@@ -42,6 +43,7 @@ export class FileStore implements AppStore {
       source_hash: "",
       config: {},
       secrets: {},
+      env: getEnv(),
     }, getLocalConfig(cwd), { secrets: getLocalSecrets(cwd) })
 
     if (this.options.config)

--- a/src/app/stores/utils.ts
+++ b/src/app/stores/utils.ts
@@ -1,0 +1,32 @@
+import * as path from 'path'
+import * as YAML from 'js-yaml'
+import * as fs from 'fs-extra'
+
+const secretsFile = ".fly.secrets.yml"
+const configFile = ".fly.yml"
+
+export function getLocalSecrets(cwd = process.cwd()) {
+  const localSecretsPath = path.join(cwd, secretsFile)
+  let secrets = {};
+
+  if (fs.existsSync(localSecretsPath))
+    secrets = YAML.load(fs.readFileSync(localSecretsPath).toString())
+
+  return secrets
+}
+
+export function getLocalConfig(
+  cwd = process.cwd(),
+  env = getEnv()
+) {
+  const localConfigPath = path.join(cwd, configFile)
+  let config: any = {};
+  if (fs.existsSync(localConfigPath))
+    config = YAML.load(fs.readFileSync(localConfigPath).toString())
+
+  return config[env] || config
+}
+
+export function getEnv() {
+  return process.env.FLY_ENV || process.env.NODE_ENV || 'development'
+}

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -1,6 +1,6 @@
 import { root, getAppId } from './root'
 import { API } from './api'
-import { getLocalConfig } from '../app/config'
+import { getLocalConfig } from '../app/stores/utils'
 import { processResponse } from '../utils/cli'
 
 export interface DeployOptions { }

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -1,6 +1,5 @@
 import { create, Command } from "commandpost";
-
-import { getLocalConfig } from "../app/config"
+import { getLocalConfig } from '../app/stores/utils'
 
 import YAML = require('js-yaml')
 import fs = require('fs-extra')

--- a/test/app/stores/file.spec.ts
+++ b/test/app/stores/file.spec.ts
@@ -3,6 +3,15 @@ import { FileStore } from '../../../src/app/stores/file'
 
 
 describe('FileStore', function() {
+  const env = Object.assign({}, process.env);
+  before(async function() {
+    process.env = env
+  })
+  after(function(done) {
+    process.env = env
+    done()
+  })
+
   describe('initialize', () => {
     it('throws error when bad working directory path is provided', async () => {
       assert.throws(() => new FileStore("badpath"), Error, /Could not find path/)
@@ -31,6 +40,16 @@ describe('FileStore', function() {
         "password": "sekret"
       })
     })
-  })
 
+    it('picks config environment', async () => {
+      process.env.FLY_ENV = 'stage'
+      let store = new FileStore(__dirname + '/testdata/config-multi-env', { noWatch: true })
+      expect(store.releaseInfo.app_id).to.equal("config-multi-env")
+      expect(store.releaseInfo.config).to.eql({
+        "option_a": "val_a",
+        "password": "sekret"
+      })
+      expect(store.releaseInfo.env).to.equal("stage")
+    })
+  })
 })

--- a/test/app/stores/testdata/config-multi-env/.fly.secrets.yml
+++ b/test/app/stores/testdata/config-multi-env/.fly.secrets.yml
@@ -1,0 +1,1 @@
+my_app_password: 'sekret'

--- a/test/app/stores/testdata/config-multi-env/.fly.yml
+++ b/test/app/stores/testdata/config-multi-env/.fly.yml
@@ -1,0 +1,18 @@
+default: &default
+  app_id: config-multi-env
+  config:
+    secrets: &secrets
+      password:
+        fromSecret: my_app_password
+
+stage: &stage
+  <<: *default
+  config:
+    option_a: val_a
+    <<: *secrets
+
+production: &production
+  <<: *default
+  config:
+    option_b: val_b
+    <<: *secrets

--- a/test/app/stores/testdata/config-multi-env/index.js
+++ b/test/app/stores/testdata/config-multi-env/index.js
@@ -1,0 +1,3 @@
+fly.http.respondWith(function(request) {
+  return new Response("hello")
+})


### PR DESCRIPTION
BREAKING CHANGE: App is not going to call `parseConfig` to interpolate
the config entries and inject secret values. Each store should ensure
that a config is properly parsed before providing a ReleaseInfo.

Currently, there's unnecessary coupling between the ReleaseInfo and App.
E.g. FileStore acts dynamically and has to parse config and secrets on
each reload (which happens when either file has changed), however in
production, config might be loaded only once. Only the Store itself
knows when parsing should happen.