### PR TITLE
Change app naming scheme to be simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ open http://localhost:3000
 By default, fly will read your a `.fly.yml` file in your current working directory.
 
 ```yaml
-app_id: my-app-id
+app: my-app-name
 config:
   foo: bar
 ```
@@ -56,7 +56,7 @@ config:
 
 Located in your `.fly.yml` file.
 
-- `app_id` - the fly.io app id, can be ommitted, useful for deployment purposes
+- `app` - the fly.io app name, can be ommitted, useful for deployment purposes
 - `config` - arbitrary settings for your applications, accessible in your code via the global variable `app.config`
 
 #### Server configuration

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import { parseConfig } from './app/config'
 import { ivm } from './';
 
 export interface ReleaseInfo {
-  app_id: string
+  name: string
   version: number
   source: string
   source_hash: string
@@ -13,13 +13,13 @@ export interface ReleaseInfo {
 }
 
 export class App {
-  id: string
+  name: string
   env: string
   releaseInfo: ReleaseInfo
   private _config: any
 
   constructor(releaseInfo: ReleaseInfo) {
-    this.id = releaseInfo.app_id
+    this.name = releaseInfo.name
     this.env = releaseInfo.env
     this.releaseInfo = releaseInfo
   }
@@ -50,7 +50,7 @@ export class App {
 
   forV8() {
     return new ivm.ExternalCopy({
-      id: this.id,
+      name: this.name,
       config: this.config,
       version: this.version,
       env: this.env

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import { parseConfig } from './app/config'
 import { ivm } from './';
 
 export interface ReleaseInfo {
-  name: string
+  app: string
   version: number
   source: string
   source_hash: string
@@ -13,15 +13,19 @@ export interface ReleaseInfo {
 }
 
 export class App {
-  name: string
-  env: string
   releaseInfo: ReleaseInfo
   private _config: any
 
   constructor(releaseInfo: ReleaseInfo) {
-    this.name = releaseInfo.name
-    this.env = releaseInfo.env
     this.releaseInfo = releaseInfo
+  }
+
+  get name() {
+    return this.releaseInfo.app
+  }
+
+  get env() {
+    return this.releaseInfo.env
   }
 
   get config() {

--- a/src/app/stores/file.ts
+++ b/src/app/stores/file.ts
@@ -40,10 +40,10 @@ export class FileStore implements AppStore {
     const env = options.env || getEnv()
 
     const localConf = getLocalConfig(cwd, env)
-    localConf.name = localConf.app
+    localConf.app = localConf.app
 
     this.releaseInfo = Object.assign({}, {
-      name: this.cwd,
+      app: this.cwd,
       version: 0,
       source: "",
       source_hash: "",

--- a/src/app/stores/file.ts
+++ b/src/app/stores/file.ts
@@ -39,15 +39,18 @@ export class FileStore implements AppStore {
 
     const env = options.env || getEnv()
 
+    const localConf = getLocalConfig(cwd, env)
+    localConf.name = localConf.app
+
     this.releaseInfo = Object.assign({}, {
-      app_id: this.cwd,
+      name: this.cwd,
       version: 0,
       source: "",
       source_hash: "",
       config: {},
       secrets: {},
       env: env,
-    }, getLocalConfig(cwd, env), { secrets: getLocalSecrets(cwd) })
+    }, localConf, { secrets: getLocalSecrets(cwd) })
 
     if (this.options.config)
       this.releaseInfo.config = this.options.config

--- a/src/app/stores/file.ts
+++ b/src/app/stores/file.ts
@@ -40,7 +40,7 @@ export class FileStore implements AppStore {
     const env = options.env || getEnv()
 
     const localConf = getLocalConfig(cwd, env)
-    localConf.app = localConf.app
+    localConf.app = localConf.app || localConf.app_id
 
     this.releaseInfo = Object.assign({}, {
       app: this.cwd,

--- a/src/bridge/fly/cache.ts
+++ b/src/bridge/fly/cache.ts
@@ -13,7 +13,7 @@ registerBridge('flyCacheSet', function cacheSet(ctx: Context, config: Config, ke
   if (!ctx.meta.app)
     return ctx.tryCallback(callback, ["app not present, something is wrong"])
 
-  let k = "cache:" + ctx.meta.app.id + ":" + key
+  let k = "cache:" + ctx.meta.app.name + ":" + key
 
   if (!config.cacheStore)
     return ctx.tryCallback(callback, [errCacheStoreUndefined.toString()])
@@ -42,7 +42,7 @@ registerBridge('flyCacheExpire', function cacheExpire(ctx: Context, config: Conf
   ctx.addCallback(callback)
   if (!ctx.meta.app)
     return ctx.tryCallback(callback, ["app not present, something is wrong"])
-  let k = "cache:" + ctx.meta.app.id + ":" + key
+  let k = "cache:" + ctx.meta.app.name + ":" + key
 
   if (!config.cacheStore) {
     ctx.tryCallback(callback, [errCacheStoreUndefined.toString()])
@@ -69,7 +69,7 @@ registerBridge('flyCacheGet',
       ctx.tryCallback(callback, [errCacheStoreUndefined.toString()])
       return
     }
-    let k = "cache:" + ctx.meta.app.id + ":" + key
+    let k = "cache:" + ctx.meta.app.name + ":" + key
 
     config.cacheStore.get(k).then((buf) => {
       const size = buf ? buf.byteLength : 0

--- a/src/bridge/logger.ts
+++ b/src/bridge/logger.ts
@@ -34,7 +34,7 @@ registerBridge('addLogTransport', async function (
       case TransportType.Syslog:
         const ip = await resolveHostname(options.host)
         ctx.logger.add(Syslog, Object.assign(options, {
-          app_name: ctx.meta.app && ctx.meta.app.id || "app",
+          app_name: ctx.meta.app && ctx.meta.app.name || "app",
           host: ip,
           protocol: 'udp4'
         }));

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -1,4 +1,4 @@
-import { root, getAppId } from './root'
+import { root, getAppName } from './root'
 import { API } from './api'
 import { getLocalConfig } from '../app/stores/utils'
 import { processResponse } from '../utils/cli'
@@ -11,13 +11,13 @@ root
   .description("Deploy your local Fly app.")
   .action((opts, args, rest) => {
     const { buildApp } = require('../utils/build')
-    const appID = getAppId("production")
-    console.log("Deploying", appID)
+    const appName = getAppName("production")
+    console.log("Deploying", appName)
     buildApp(process.cwd(), { watch: false, uglify: true }, async (err: Error, source: string, hash: string, sourceMap: string) => {
       try {
         if (err)
           throw err
-        const res = await API.post(`/api/v1/apps/${appID}/releases`, {
+        const res = await API.post(`/api/v1/apps/${appName}/releases`, {
           data: {
             attributes: {
               source: source,

--- a/src/cmd/fetch.ts
+++ b/src/cmd/fetch.ts
@@ -1,4 +1,4 @@
-import { root, getAppId } from './root'
+import { root, getAppName } from './root'
 import { API } from './api'
 import { processResponse } from '../utils/cli'
 
@@ -10,8 +10,8 @@ root
   .description("Fetch your Fly app locally.")
   .action(async (opts, args, rest) => {
     try {
-      const appID = getAppId()
-      const res = await API.get(`/api/v1/apps/${appID}/source`)
+      const appName = getAppName()
+      const res = await API.get(`/api/v1/apps/${appName}/source`)
       processResponse(res, (res: any) => {
         console.log(res.data.data.attributes.source)
       })

--- a/src/cmd/hostnames.ts
+++ b/src/cmd/hostnames.ts
@@ -1,4 +1,4 @@
-import { root, getAppId } from './root'
+import { root, getAppName } from './root'
 import { API } from './api'
 import { processResponse } from '../utils/cli'
 
@@ -10,7 +10,7 @@ const hostnames = root
   .description("Manage Fly app's hostnames.")
   .action(async (opts, args, rest) => {
     try {
-      const res = await API.get(`/api/v1/apps/${getAppId()}/hostnames`)
+      const res = await API.get(`/api/v1/apps/${getAppName()}/hostnames`)
       processResponse(res, (res: any) => {
         if (!res.data.data || res.data.data.length === 0)
           return console.log("No hostnames configured, use `fly hostnames add` to add one.")
@@ -36,7 +36,7 @@ hostnames
   .description("Add a hostname to your fly app.")
   .action(async (opts, args, rest) => {
     try {
-      const res = await API.post(`/api/v1/apps/${getAppId()}/hostnames`, { data: { attributes: { hostname: args.hostname } } })
+      const res = await API.post(`/api/v1/apps/${getAppName()}/hostnames`, { data: { attributes: { hostname: args.hostname } } })
       processResponse(res, (res: any) => {
         console.log(`Successfully added hostname ${args.hostname}`)
       })

--- a/src/cmd/logs.ts
+++ b/src/cmd/logs.ts
@@ -1,4 +1,4 @@
-import { root, getAppId } from './root'
+import { root, getAppName } from './root'
 import { API } from './api'
 import { processResponse } from '../utils/cli'
 
@@ -13,22 +13,22 @@ root
   .subCommand<LogsOptions, LogsArgs>("logs")
   .description("Logs from your app.")
   .action(async (opts, args, rest) => {
-    continuouslyGetLogs(getAppId())
+    continuouslyGetLogs(getAppName())
   })
 
-async function continuouslyGetLogs(appID: string) {
-  log.silly("continuously get logs for app id:", appID)
+async function continuouslyGetLogs(appName: string) {
+  log.silly("continuously get logs for app id:", appName)
   let lastNextToken: string | undefined;
   while (true) {
     try {
-      const [logs, nextToken] = await getLogs(appID, lastNextToken)
+      const [logs, nextToken] = await getLogs(appName, lastNextToken)
       lastNextToken = nextToken
       showLogs(logs)
     } catch (e) {
       if (e.response)
         processResponse(e.response)
       else
-        console.log(e)
+        console.log(e.stack)
       break;
     }
     await sleep(5000) // give it a rest!
@@ -59,8 +59,8 @@ async function showLogs(logs: Log[]) {
   }
 }
 
-async function getLogs(appID: string, nextToken?: string): Promise<[any[], string | undefined]> {
-  const res = await API.get(`/api/v1/apps/${appID}/logs`, {
+async function getLogs(appName: string, nextToken?: string): Promise<[any[], string | undefined]> {
+  const res = await API.get(`/api/v1/apps/${appName}/logs`, {
     params: { next_token: nextToken }
   })
   if (res.data.data && res.data.meta) {

--- a/src/cmd/releases.ts
+++ b/src/cmd/releases.ts
@@ -1,4 +1,4 @@
-import { root, getAppId } from './root'
+import { root, getAppName } from './root'
 import { API } from './api'
 import { processResponse } from '../utils/cli'
 
@@ -10,11 +10,11 @@ root
   .description("Manage Fly apps.")
   .action(async (opts, args, rest) => {
     try {
-      const appID = getAppId()
-      const res = await API.get(`/api/v1/apps/${appID}/releases`)
+      const appName = getAppName()
+      const res = await API.get(`/api/v1/apps/${appName}/releases`)
       processResponse(res, (res: any) => {
         if (res.data.data.length == 0)
-          return console.log(`No releases for ${appID} yet.`)
+          return console.log(`No releases for ${appName} yet.`)
         for (let r of res.data.data) {
           console.log(`v${r.attributes.version} ${r.attributes.reason} by ${r.attributes.author} on ${r.attributes.created_at}`)
         }

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -7,17 +7,14 @@ import path = require('path')
 
 const { version } = require('../../package.json')
 
-export interface RootOptions {
+export interface CommonOptions {
   app?: string[]
   env?: string[]
   token: string[]
 }
 
-export interface RootArgs {
-}
-
 export const root =
-  create<RootOptions, RootArgs>("fly")
+  create<CommonOptions, any>("fly")
     .version(version, "-v, --version")
     .description("Fly CLI")
     .option("-a, --app <id>", "App to use for commands.")
@@ -43,22 +40,22 @@ export function getToken() {
   return token
 }
 
-export const fullAppMatch = /([a-z0-9_.-]+)\/([a-z0-9_.-]+)/i
+export const fullAppMatch = /([a-z0-9_.-]+)/i
 
-export function getAppId(env = "production") {
+export function getAppName(env = "production") {
   const cwd = process.cwd()
   env = root.parsedOpts.env && root.parsedOpts.env[0] || process.env.FLY_ENV || env || "production"
   const conf = getLocalConfig(cwd, env)
-  const appId = root.parsedOpts.app && root.parsedOpts.app[0] || conf.app_id
+  const appName = root.parsedOpts.app && root.parsedOpts.app[0] || conf.app || conf.app_id
 
-  if (!appId) {
-    throw new Error("--app option or app_id (in your .fly.yml) needs to be set.")
+  if (!appName) {
+    throw new Error("--app option or app (in your .fly.yml) needs to be set.")
   }
 
-  if (!appId.match(fullAppMatch))
+  if (!appName.match(fullAppMatch))
     throw new Error("app parameter needs to match a full org/app name (ie: your-org/app-name)")
 
-  return appId
+  return appName
 }
 
 export function homeConfigPath() {

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -1,5 +1,5 @@
 import fs = require('fs')
-import { root, getAppId } from './root'
+import { root, getAppName } from './root'
 import { API } from './api'
 import { processResponse } from '../utils/cli'
 
@@ -22,7 +22,7 @@ secrets
   .usage("fly secrets set <key> [value]")
   .action(async (opts, args, rest) => {
     try {
-      const appID = getAppId()
+      const appName = getAppName()
 
       const value = opts.filename ?
         fs.readFileSync(opts.filename[0]).toString() :
@@ -31,7 +31,7 @@ secrets
       if (!value)
         throw new Error("Either a value or --from-file needs to be provided.")
 
-      const res = await API.patch(`/api/v1/apps/${appID}/secrets`, {
+      const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
         data: {
           attributes: {
             key: args.key,

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,3 +1,5 @@
+import { getToken } from "../cmd/root";
+
 function getErrorMessages(res: any): string[] {
   if (res.data.errors) {
     return res.data.errors.map((err: any) => errorMessage(err))
@@ -13,6 +15,9 @@ function errorMessage(err: any): string {
   } else if (err.title) {
     return err.title
   } else if (err.detail) {
+    if (err.source && err.source.pointer)
+      if (err.source.pointer.startsWith("/data/attributes/"))
+        return `${err.source.pointer.replace("/data/attributes/", "")} ${err.detail}`
     return err.detail
   }
   return ''
@@ -23,6 +28,8 @@ export function processResponse(res: any, successFn?: Function | undefined): voi
     if (successFn)
       successFn(res)
   } else {
+    if (res.status == 401) // TODO: Store and use `refresh_token` to automatically fix this predicament
+      return console.log("Please login again with `fly login`, your token is probably expired.")
     for (let errMsg of getErrorMessages(res)) {
       console.log(errMsg)
     }

--- a/test/app/stores/file.spec.ts
+++ b/test/app/stores/file.spec.ts
@@ -2,12 +2,12 @@ import { expect, assert } from 'chai'
 import { FileStore } from '../../../src/app/stores/file'
 
 
-describe('FileStore', function() {
+describe('FileStore', function () {
   const env = Object.assign({}, process.env);
-  before(async function() {
+  before(async function () {
     process.env = env
   })
-  after(function(done) {
+  after(function (done) {
     process.env = env
     done()
   })
@@ -29,12 +29,12 @@ describe('FileStore', function() {
 
     it('loads app with config file', async () => {
       let store = new FileStore(__dirname + '/testdata/config-no-secrets', { noWatch: true })
-      expect(store.releaseInfo.app_id).to.equal("config-no-secrets")
+      expect(store.releaseInfo.name).to.equal("config-no-secrets")
     })
 
     it('interpolates secrets correctly', async () => {
       let store = new FileStore(__dirname + '/testdata/config-and-secrets', { noWatch: true })
-      expect(store.releaseInfo.app_id).to.equal("config-and-secrets")
+      expect(store.releaseInfo.name).to.equal("config-and-secrets")
       expect(store.releaseInfo.config).to.eql({
         "option_a": "val_a",
         "password": "sekret"
@@ -44,7 +44,7 @@ describe('FileStore', function() {
     it('picks config environment', async () => {
       process.env.FLY_ENV = 'stage'
       let store = new FileStore(__dirname + '/testdata/config-multi-env', { noWatch: true })
-      expect(store.releaseInfo.app_id).to.equal("config-multi-env")
+      expect(store.releaseInfo.name).to.equal("config-multi-env")
       expect(store.releaseInfo.config).to.eql({
         "option_a": "val_a",
         "password": "sekret"

--- a/test/app/stores/file.spec.ts
+++ b/test/app/stores/file.spec.ts
@@ -29,12 +29,12 @@ describe('FileStore', function () {
 
     it('loads app with config file', async () => {
       let store = new FileStore(__dirname + '/testdata/config-no-secrets', { noWatch: true })
-      expect(store.releaseInfo.name).to.equal("config-no-secrets")
+      expect(store.releaseInfo.app).to.equal("config-no-secrets")
     })
 
     it('interpolates secrets correctly', async () => {
       let store = new FileStore(__dirname + '/testdata/config-and-secrets', { noWatch: true })
-      expect(store.releaseInfo.name).to.equal("config-and-secrets")
+      expect(store.releaseInfo.app).to.equal("config-and-secrets")
       expect(store.releaseInfo.config).to.eql({
         "option_a": "val_a",
         "password": "sekret"
@@ -44,7 +44,7 @@ describe('FileStore', function () {
     it('picks config environment', async () => {
       process.env.FLY_ENV = 'stage'
       let store = new FileStore(__dirname + '/testdata/config-multi-env', { noWatch: true })
-      expect(store.releaseInfo.name).to.equal("config-multi-env")
+      expect(store.releaseInfo.app).to.equal("config-multi-env")
       expect(store.releaseInfo.config).to.eql({
         "option_a": "val_a",
         "password": "sekret"

--- a/test/app/stores/testdata/config-and-secrets/.fly.yml
+++ b/test/app/stores/testdata/config-and-secrets/.fly.yml
@@ -1,4 +1,4 @@
-app_id: config-and-secrets
+app: config-and-secrets
 config:
   option_a: val_a
   password:

--- a/test/app/stores/testdata/config-multi-env/.fly.yml
+++ b/test/app/stores/testdata/config-multi-env/.fly.yml
@@ -1,5 +1,5 @@
 default: &default
-  app_id: config-multi-env
+  app: config-multi-env
   config:
     secrets: &secrets
       password:

--- a/test/app/stores/testdata/config-no-secrets/.fly.yml
+++ b/test/app/stores/testdata/config-no-secrets/.fly.yml
@@ -1,3 +1,3 @@
-app_id: config-no-secrets
+app: config-no-secrets
 config:
   option_a: val_a

--- a/test/context.spec.ts
+++ b/test/context.spec.ts
@@ -7,7 +7,7 @@ describe('Context', () => {
   describe('no leaks!', () => {
     before(async function () {
       await v8Env.waitForReadiness()
-      this.iso = new ivm.Isolate({ memoryLimit: 96, snapshot: v8Env.snapshot })
+      this.iso = new ivm.Isolate({ memoryLimit: 128, snapshot: v8Env.snapshot })
       this.ctx = await createDefaultContext(this.iso)
     })
     after(async function () {
@@ -24,6 +24,7 @@ describe('Context', () => {
     })
 
     it('does not leak (in a major way) when creating contexts profusely', async function () {
+      this.timeout(10000)
       const initHeap = this.iso.getHeapStatisticsSync().used_heap_size
       for (let i = 0; i < 200; i++) {
         let ctx = await createDefaultContext(this.iso)

--- a/test/context.spec.ts
+++ b/test/context.spec.ts
@@ -29,7 +29,6 @@ describe('Context', () => {
         let ctx = await createDefaultContext(this.iso)
         await ctx.finalize()
         await ctx.release()
-        console.log("heap:", this.iso.getHeapStatisticsSync().used_heap_size / (1024 * 1024))
       }
       expect(this.iso.getHeapStatisticsSync().used_heap_size).to.be.within(
         initHeap - (1024 * 1024),

--- a/test/fixtures/apps/fails/async-app/.fly.yml
+++ b/test/fixtures/apps/fails/async-app/.fly.yml
@@ -1,1 +1,1 @@
-app_id: test-app-id
+app: test-app-id

--- a/test/fixtures/apps/fly-backend/.fly.yml
+++ b/test/fixtures/apps/fly-backend/.fly.yml
@@ -1,1 +1,1 @@
-app_id: backend-app
+app: backend-app

--- a/test/fixtures/apps/fly-cache/.fly.yml
+++ b/test/fixtures/apps/fly-cache/.fly.yml
@@ -1,1 +1,1 @@
-app_id: test-app-id
+app: test-app-id

--- a/test/fixtures/apps/fly-routes/.fly.yml
+++ b/test/fixtures/apps/fly-routes/.fly.yml
@@ -1,4 +1,4 @@
-app_id: routes-app
+app: routes-app
 config:
   backends:
     - id: 1

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -229,7 +229,7 @@ describe('Server', () => {
     after(function (done) { this.server.close(done) })
 
     it('works', async function () {
-      this.timeout(10000) // give it some leeway
+      this.timeout(30000) // give it some leeway
       let res = await axios.post("http://127.0.0.1:3333/", "hello", { headers: { host: "test" } })
       expect(res.status).to.equal(200)
     })


### PR DESCRIPTION
We used to follow Github-like conventions, but turns out we prefer the simpler heroku conventions. Name is optional on creation, will generate a fun one for you if omitted.