### PR TITLE
feat: API docs published with npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .nyc_output
 bin/fly
 .fly
+doc/

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ npm install --save-dev @fly/fly
 Write javascript code to a file (`index.js`):
 
 ```js
-// fly.http.respondWith is just a convenient wrapper
-// around addEventListener('fetch', function(event){})
 fly.http.respondWith(function(request){
   return new Response("Hello! We support whirled peas.", { status: 200})
 })
+// if you'd prefer to be service worker compatibility, this is alos supported:
+// around addEventListener('fetch', function(event){})
 ```
 
 Start the fly server:

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,18 @@
         "@types/node": "8.5.8"
       }
     },
+    "@types/handlebars": {
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
+      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
+      "dev": true
+    },
+    "@types/highlight.js": {
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
+      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
+      "dev": true
+    },
     "@types/ioredis": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-3.2.5.tgz",
@@ -144,6 +156,18 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.10.1.tgz",
       "integrity": "sha512-IpKg0KGIUNcydttaGURhSLrq1eSNoSjN7T1MokAuasIPBKzsHxcz3MAdFGzasmYQVWf6XxG+jQTJ9UFOL29Ubg==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.104",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
+      "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
+      "integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
       "dev": true
     },
     "@types/minimatch": {
@@ -199,6 +223,16 @@
       "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.17.6.tgz",
       "integrity": "sha512-gN4g+ZHsJA9ZEUq9a2NiOovlZe7mZH1cIJwEJEj2xDe4esghnQkNnbp4nOhwPX7q4Abp/wpxYDOxwk0MvoTFhA==",
       "requires": {
+        "@types/node": "8.5.8"
+      }
+    },
+    "@types/shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "5.0.35",
         "@types/node": "8.5.8"
       }
     },
@@ -5787,6 +5821,12 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7053,6 +7093,12 @@
       "requires": {
         "object-visit": "1.0.1"
       }
+    },
+    "marked": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
+      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
@@ -9966,6 +10012,12 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -10200,6 +10252,15 @@
         "minimatch": "3.0.4",
         "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
       }
     },
     "redent": {
@@ -10658,6 +10719,17 @@
         "array-map": "0.0.0",
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
+      "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "signal-exit": {
@@ -11830,6 +11902,58 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedoc": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.11.1.tgz",
+      "integrity": "sha512-jdNIoHm5wkZqxQTe/g9AQ3LKnZyrzHXqu6A/c9GUOeJyBWLxNr7/Dm3rwFvLksuxRNwTvY/0HRDU9sJTa9WQSg==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "5.0.1",
+        "@types/handlebars": "4.0.36",
+        "@types/highlight.js": "9.12.2",
+        "@types/lodash": "4.14.104",
+        "@types/marked": "0.3.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "0.7.8",
+        "fs-extra": "5.0.0",
+        "handlebars": "4.0.11",
+        "highlight.js": "9.12.0",
+        "lodash": "4.17.5",
+        "marked": "0.3.17",
+        "minimatch": "3.0.4",
+        "progress": "2.0.0",
+        "shelljs": "0.8.1",
+        "typedoc-default-themes": "0.5.0",
+        "typescript": "2.7.2"
+      },
+      "dependencies": {
+        "@types/fs-extra": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+          "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.5.8"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+      "dev": true
+    },
+    "typedoc-plugin-external-module-name": {
+      "version": "github:superfly/typedoc-plugin-external-module-name#f44e28268c0b5a3be85049e0e2ef01da2698006c",
+      "dev": true
     },
     "typescript": {
       "version": "2.7.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "files": [
     "lib/",
     "dist/",
-    "v8env/testing"
+    "v8env/testing",
+    "doc/"
   ],
   "scripts": {
     "start": "./bin/fly server ./apps/getting-started",
@@ -20,8 +21,9 @@
     "build:v8env": "webpack --config webpack.v8.config.js",
     "build:cli": "tsc bin/fly.ts",
     "build:cli:live": "npm run build:cli -- -w",
-    "prepublishOnly": "npm run build",
-    "release": "standard-version"
+    "prepublishOnly": "npm run build && npm run doc:v8env",
+    "release": "standard-version",
+    "doc:v8env": "./node_modules/.bin/typedoc --tsconfig ./v8env/ts/tsconfig.json"
   },
   "bin": {
     "fly": "lib/cmd/index.js"
@@ -70,6 +72,8 @@
     "to-arraybuffer": "^1.0.1",
     "ts-loader": "^3.2.0",
     "ts-node": "^3.3.0",
+    "typedoc": "^0.11.1",
+    "typedoc-plugin-external-module-name": "github:superfly/typedoc-plugin-external-module-name",
     "typescript": "^2.7.2",
     "url-parse": "^1.2.0",
     "url-search-params": "^0.10.0",

--- a/v8env/ts/blob.ts
+++ b/v8env/ts/blob.ts
@@ -1,7 +1,13 @@
+/** 
+ * @module fly
+ * @private
+ */
 import { TextEncoder } from "text-encoding";
 
+/** @hidden */
 export type BlobPart = BufferSource | USVString | Blob
 
+/** @hidden */
 export default class Blob {
   readonly size: number;
   readonly type: string;
@@ -60,6 +66,7 @@ export default class Blob {
   }
 }
 
+/** @hidden */
 function concatenate(...arrays: Uint8Array[]): Uint8Array {
   let totalLength = 0;
   for (let arr of arrays) {

--- a/v8env/ts/body_mixin.ts
+++ b/v8env/ts/body_mixin.ts
@@ -1,18 +1,25 @@
+/** @module fly
+ * @private
+ */
 import { parse as queryParse } from 'querystring'
 
+/** @hidden */
 interface ReadableStreamController {
   enqueue(chunk: string | ArrayBuffer): void
   close(): void
 }
+/** @hidden */
 declare var ReadableStream: {
   prototype: ReadableStream;
   new(source: any | undefined): ReadableStream;
 };
 
+/** @hidden */
 export type BodySource = Blob | BufferSource |
   FormData | URLSearchParams |
   ReadableStream | String
 
+/** @hidden */
 export default class BodyMixin implements Body {
   private readonly bodySource: BodySource
   private stream: ReadableStream | null
@@ -104,6 +111,7 @@ export default class BodyMixin implements Body {
   }
 }
 
+/** @hidden */
 function bufferFromStream(stream: ReadableStreamReader): Promise<ArrayBuffer> {
   return new Promise((resolve, reject) => {
     let parts: Array<Uint8Array> = [];
@@ -135,6 +143,7 @@ function bufferFromStream(stream: ReadableStreamReader): Promise<ArrayBuffer> {
     })()
   })
 }
+/** @hidden */
 function concatenate(...arrays: Uint8Array[]): ArrayBuffer {
   let totalLength = 0;
   for (let arr of arrays) {

--- a/v8env/ts/form_data.ts
+++ b/v8env/ts/form_data.ts
@@ -1,7 +1,12 @@
+/**
+ * @module fly
+ * @private
+ */
 import { stringify } from 'querystring'
 
 /**
  * Class representing a fetch response.
+ * @hidden
  */
 export default class FormData {
   private _data: Map<string, string[]>

--- a/v8env/ts/logger.ts
+++ b/v8env/ts/logger.ts
@@ -1,7 +1,13 @@
+/**
+ * @module fly
+ * @private
+ */
 import { format } from 'util'
 
+/** @hidden */
 declare var global: any
 
+/** @hidden */
 export const logger = {
   info(fmt: any, ...params: any[]) {
     flyLog('info', format(fmt, ...params))
@@ -14,6 +20,7 @@ export const logger = {
   }
 }
 
+/** @hidden */
 function flyLog(lvl: string, message: string) {
   if (global._log)
     global._log.apply(null, [lvl, message]);

--- a/v8env/ts/tsconfig.json
+++ b/v8env/ts/tsconfig.json
@@ -17,11 +17,11 @@
     /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "declaration": true, /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,
     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "../lib",                    /* Redirect output structure to the directory. */
+    "outDir": "../lib", /* Redirect output structure to the directory. */
     // "rootDir": ".", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -33,7 +33,7 @@
     /* Enable all strict type-checking options. */
     "noImplicitAny": true,
     /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictNullChecks": true, /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
@@ -49,7 +49,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [
       "./types/"
-    ],                                        /* List of folders to include type definitions from. */
+    ], /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
@@ -62,5 +62,14 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "typedocOptions": {
+    "out": "./doc/",
+    "includeDeclarations": true,
+    "excludeExternals": true,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    "plugins": "@fly/typedoc-plugin-external-module-name",
+    "mode": "modules"
   }
 }

--- a/v8env/ts/types/fetch.d.ts
+++ b/v8env/ts/types/fetch.d.ts
@@ -1,0 +1,38 @@
+/**
+ * @module fetch
+ */
+/**
+ * The `fetch()` method starts the process of fetching a resource form the network.
+ * This returns a promise that resolves to the `Response` object representing the
+ * response to your request.
+ */
+declare function fetch(input: FlyRequestInfo, init?: RequestInit): Promise<Response>;
+
+type FlyRequestInfo = Request | string;
+
+interface RequestInit {
+  signal?: AbortSignal;
+  body?: Blob | BufferSource | FormData | string | null;
+  cache?: RequestCache;
+  credentials?: RequestCredentials;
+  headers?: HeadersInit;
+  integrity?: string;
+  keepalive?: boolean;
+  method?: string;
+  mode?: RequestMode;
+  redirect?: RequestRedirect;
+  referrer?: string;
+  referrerPolicy?: ReferrerPolicy;
+}
+
+interface Response extends Object, Body {
+  readonly body: ReadableStream | null;
+  readonly headers: Headers;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType;
+  readonly url: string;
+  readonly redirected: boolean;
+  clone(): Response;
+}

--- a/v8env/ts/types/fly.d.ts
+++ b/v8env/ts/types/fly.d.ts
@@ -1,0 +1,70 @@
+/**
+ * @module fly
+ * @preferred
+ */
+/**
+ * Fly specific APIs and functionality
+ * @module fly
+ * @preferred
+ */
+declare module fly {
+  /**
+   * The Fly HTTP interface, use this to work with HTTP requests
+   */
+  namespace http {
+    export function respondWith(response: Promise<Response> | Response | ((req: Request) => Promise<Response>)): void
+  }
+  namespace log {
+    export function log(lvl: string, ...args: any[]): void
+    export function addTransport(name: string, options: any): void
+    export function addMetadata(metadata: any): void
+  }
+  namespace util {
+    namespace md5 {
+      /**
+       * Creates an md5 hash of a string.
+       * @param s The string value to hash
+       * @returns a string representation of an md5 hash
+       */
+      export function hash(s: string): string
+    }
+  }
+  namespace cache {
+    /**
+     * Get an ArrayBuffer value (or null) from the cache. See `getString` if you 
+     * want a string value.
+     * @param key The key to get
+     * @return  Raw bytes stored for provided key or null if empty.
+     */
+    export function get(key: string): Promise<ArrayBuffer | null>
+
+    /**
+     * Get a string value (or null) from the cache
+     * @param key The key to get
+     * @returns Data stored at the key, or null if none exists
+     */
+    export function getString(key: string): Promise<string | null>
+
+    /**
+     * Sets a value at a certain key, with an optional ttl
+     * @param key The key to add or overwrite
+     * @param value Data to store at the specified key, up to 2MB
+     * @param [ttl] Time to live (in seconds)
+     * @returns true if the set was successful
+     */
+    export function set(key: string, value: string | ArrayBuffer, ttl?: number): Promise<boolean>
+
+    /** 
+     * Sets or overwrites a key's time to live (in seconds)
+     * @param key The key to modify
+     * @param ttl Expiration time remaining in seconds
+     * @returns true if ttl was set successfully
+     */
+    export function expire(key: string, ttl: number): Promise<boolean>
+  }
+  //export const streams: any
+  /**
+   * An image manipulation library. Useful for resizing and optimizing images.
+   */
+  //export const Image: img.Image
+}

--- a/v8env/ts/types/querystring.d.ts
+++ b/v8env/ts/types/querystring.d.ts
@@ -1,3 +1,8 @@
+/**
+ * @module fly
+ * @private
+ */
+/** @hidden */
 declare module "querystring" {
   export interface StringifyOptions {
     encodeURIComponent?: Function;

--- a/v8env/ts/types/text-encoding.d.ts
+++ b/v8env/ts/types/text-encoding.d.ts
@@ -1,8 +1,13 @@
+/**
+ * @module fly
+ * @private
+ */
 // Type definitions for text-encoding
 // Project: https://github.com/inexorabletash/text-encoding
 // Definitions by: MIZUNE Pine <https://github.com/pine613>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/** @hidden */
 declare namespace TextEncoding {
     interface TextDecoderOptions {
         fatal?: boolean;
@@ -35,12 +40,12 @@ declare namespace TextEncoding {
 
     interface TextEncoderStatic {
         (utfLabel?: string, options?: TextEncoderOptions): TextEncoder;
-        new (utfLabel?: string, options?: TextEncoderOptions): TextEncoder;
+        new(utfLabel?: string, options?: TextEncoderOptions): TextEncoder;
     }
 
     interface TextDecoderStatic {
         (label?: string, options?: TextDecoderOptions): TextDecoder;
-        new (label?: string, options?: TextDecoderOptions): TextDecoder;
+        new(label?: string, options?: TextDecoderOptions): TextDecoder;
     }
 
     interface TextEncodingStatic {
@@ -49,12 +54,16 @@ declare namespace TextEncoding {
     }
 }
 
+/** @hidden */
 declare var TextDecoder: TextEncoding.TextDecoderStatic;
 
+/** @hidden */
 declare var TextEncoder: TextEncoding.TextEncoderStatic;
 
+/** @hidden */
 declare var TextEncoding: TextEncoding.TextEncodingStatic;
 
+/** @hidden */
 declare module "text-encoding" {
     export = TextEncoding;
 }

--- a/v8env/ts/types/util.d.ts
+++ b/v8env/ts/types/util.d.ts
@@ -1,3 +1,8 @@
+/** 
+ * @private
+ * @module fly
+ */
+/** @hidden */
 declare module "util" {
   export function format(format: any, ...param: any[]): string;
 }


### PR DESCRIPTION
`npm run doc:v8env` now generates docs in the `/docs/` folder. These are included when published to npm.

The changes are all doc related, no functionality differences (although I did reorder the image.ts file to make the docs nicer).