### PR TITLE
fix: Support all TypedArray Response bodies

### DIFF
--- a/v8env/ts/body_mixin.ts
+++ b/v8env/ts/body_mixin.ts
@@ -93,7 +93,16 @@ export default class BodyMixin implements Body {
   }
 
   async arrayBuffer(): Promise<ArrayBuffer> {
-    if (this.bodySource instanceof Uint8Array) {
+    if (this.bodySource instanceof Int8Array ||
+        this.bodySource instanceof Int16Array ||
+        this.bodySource instanceof Int32Array ||
+        this.bodySource instanceof Uint8Array ||
+        this.bodySource instanceof Uint16Array ||
+        this.bodySource instanceof Uint32Array ||
+        this.bodySource instanceof Uint8ClampedArray ||
+        this.bodySource instanceof Float32Array ||
+        this.bodySource instanceof Float64Array
+    ) {
       const buffer = this.bodySource.buffer
       if (buffer instanceof ArrayBuffer) return buffer
     } else if (this.bodySource instanceof ArrayBuffer) {
@@ -146,6 +155,7 @@ function bufferFromStream(stream: ReadableStreamReader): Promise<ArrayBuffer> {
     })()
   })
 }
+
 /** @hidden */
 function concatenate(...arrays: Uint8Array[]): ArrayBuffer {
   let totalLength = 0;

--- a/v8env/ts/body_mixin.ts
+++ b/v8env/ts/body_mixin.ts
@@ -103,8 +103,7 @@ export default class BodyMixin implements Body {
         this.bodySource instanceof Float32Array ||
         this.bodySource instanceof Float64Array
     ) {
-      const buffer = this.bodySource.buffer
-      if (buffer instanceof ArrayBuffer) return buffer
+      return <ArrayBuffer>this.bodySource.buffer
     } else if (this.bodySource instanceof ArrayBuffer) {
       return this.bodySource
     } else if (typeof this.bodySource === 'string') {

--- a/v8env_test/request.spec.js
+++ b/v8env_test/request.spec.js
@@ -1,11 +1,8 @@
 import { expect } from 'chai'
 
 describe("Request", () => {
-  const text = "helloFLY"
+  const text = "helloFLY" //This must be a multiple of 8 charictars long (eg. 8, 16, 24)
   const buffer = new TextEncoder("utf-8").encode(text).buffer
-  const buffer16 = new TextEncoder("utf-16").encode(text).buffer
-  const buffer32 = new TextEncoder("utf-32").encode(text).buffer
-  const buffer64 = new TextEncoder("utf-64").encode(text).buffer
 
   it("can be instantiated", () => {
     expect(new Request("http://example.com")).not.to.throw
@@ -43,7 +40,7 @@ describe("Request", () => {
   })
 
   it('returns an ArrayBuffer given a Uint16Array', async () => {
-    const r = new Response(new Uint16Array(buffer16))
+    const r = new Response(new Uint16Array(buffer))
 
     expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
   })
@@ -72,16 +69,3 @@ describe("Request", () => {
     expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
   })
 })
-
-function ab2str(buf) {
-  return String.fromCharCode.apply(null, buf);
-}
-
-function str2ab(str) {
-  var buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
-  var bufView = new Uint16Array(buf);
-  for (var i = 0, strLen = str.length; i < strLen; i++) {
-    bufView[i] = str.charCodeAt(i);
-  }
-  return buf;
-}

--- a/v8env_test/request.spec.js
+++ b/v8env_test/request.spec.js
@@ -1,6 +1,12 @@
 import { expect } from 'chai'
 
 describe("Request", () => {
+  const text = "helloFLY"
+  const buffer = new TextEncoder("utf-8").encode(text).buffer
+  const buffer16 = new TextEncoder("utf-16").encode(text).buffer
+  const buffer32 = new TextEncoder("utf-32").encode(text).buffer
+  const buffer64 = new TextEncoder("utf-64").encode(text).buffer
+
   it("can be instantiated", () => {
     expect(new Request("http://example.com")).not.to.throw
   })
@@ -12,10 +18,70 @@ describe("Request", () => {
     expect(req.bodySource).to.eq(r.bodySource)
   })
 
-  it('returns an ArrayBuffer given a Uint8Array', async () => {
-    const bodyText = "hello world"
-    const r = new Response(new TextEncoder().encode(bodyText))
+  it('returns an ArrayBuffer given a Int8Array', async () => {
+    const r = new Response(new Int8Array(buffer))
 
-    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(bodyText)
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Int16Array', async () => {
+    const r = new Response(new Int16Array(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Int32Array', async () => {
+    const r = new Response(new Int32Array(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Uint8Array', async () => {
+    const r = new Response(new Uint8Array(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Uint16Array', async () => {
+    const r = new Response(new Uint16Array(buffer16))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Uint32Array', async () => {
+    const r = new Response(new Uint32Array(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Uint8ClampedArray', async () => {
+    const r = new Response(new Uint8ClampedArray(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Float32Array', async () => {
+    const r = new Response(new Float32Array(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
+  })
+
+  it('returns an ArrayBuffer given a Float64Array', async () => {
+    const r = new Response(new Float64Array(buffer))
+
+    expect(new TextDecoder("utf-8").decode(await r.arrayBuffer())).to.equal(text)
   })
 })
+
+function ab2str(buf) {
+  return String.fromCharCode.apply(null, buf);
+}
+
+function str2ab(str) {
+  var buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  var bufView = new Uint16Array(buf);
+  for (var i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}


### PR DESCRIPTION
Continuation of previous commit. This commit adds support for the rest of the `TypedArray` types (eg. `Int32Array`, `Float64Array `). 