### PR TITLE
feat: parse all cli options and commands using a new parser script

### DIFF
--- a/src/cmd/apps.ts
+++ b/src/cmd/apps.ts
@@ -38,6 +38,7 @@ root.add([{
   name: 'create',
   dontShow: true,
   takesArguments: true,
+  respondsTo: 'apps',
   mapTo: 'name',
   description: "Create a Fly app.",
   usage: `fly apps create <org/app-name>

--- a/src/cmd/apps.ts
+++ b/src/cmd/apps.ts
@@ -1,71 +1,73 @@
-// import { root, fullAppMatch } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-// import { existsSync, writeFileSync } from 'fs';
-//
-// const Table = require('cli-table2')
-//
-// interface AppsOptions { }
-// interface AppsArgs { }
-//
-// const apps = root
-//   .subCommand<AppsOptions, AppsArgs>("apps")
-//   .description("Manage Fly apps.")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const res = await API.get("/api/v1/apps")
-//       processResponse(res, (res: any) => {
-//         const table = new Table({
-//           style: { head: [] },
-//           head: ['org', 'name', 'version']
-//         })
-//         table.push(...res.data.data.map((a: any) =>
-//           [a.attributes.org, a.attributes.name, a.attributes.version]
-//         ))
-//         console.log(table.toString())
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
-//
-// interface AppsCreateOptions { }
-// interface AppsCreateArgs {
-//   name?: string
-// }
-//
-// apps
-//   .subCommand<AppsCreateOptions, AppsCreateArgs>("create [name]")
-//   .description("Create a Fly app.")
-//   .usage(`fly apps create <org/app-name>
-//
-//   - Format: org/app-name, find your organizations with \`fly orgs\`.
-//   - App name will be lowercased, accepted characters: [a-z0-9-_.]`)
-//   .action(async (opts, args, rest) => {
-//     try {
-//       let name = null;
-//       if (args.name) {
-//         if (!args.name.match(fullAppMatch))
-//           return console.log("App name, if provided, needs to match regex:", fullAppMatch)
-//         name = args.name
-//       }
-//       const res = await API.post(`/api/v1/apps`, { data: { attributes: { name: name } } })
-//       processResponse(res, (res: any) => {
-//         console.log(`App ${res.data.data.attributes.name} created!`)
-//         if (existsSync(".fly.yml"))
-//           console.log(`Add it to your .fly.yml like: \`app: ${res.data.data.attributes.name}\``)
-//         else {
-//           writeFileSync(".fly.yml", `app: ${res.data.data.attributes.name}`)
-//           console.log("Created a .fly.yml for you.")
-//         }
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         return console.log(e.response.data)
-//       console.error(e.stack)
-//       throw e
-//     }
-//   })
+import { root, fullAppMatch } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { existsSync, writeFileSync } from 'fs';
+import { COMMAND, OPTION } from './argTypes'
+
+const Table = require('cli-table2')
+
+interface AppsOptions { }
+interface AppsArgs { }
+
+root.add([{
+  type: COMMAND,
+  name: 'apps',
+  description: "Manage Fly apps.",
+  action: async () => {
+    try {
+      const res = await API.get("/api/v1/apps")
+      processResponse(res, (res: any) => {
+        const table = new Table({
+          style: { head: [] },
+          head: ['org', 'name', 'version']
+        })
+        table.push(...res.data.data.map((a: any) =>
+          [a.attributes.org, a.attributes.name, a.attributes.version]
+        ))
+        console.log(table.toString())
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+}, {
+  type: COMMAND,
+  name: 'create',
+  takesArguments: true,
+  mapTo: 'name',
+  description: "Create a Fly app.",
+  usage: `fly apps create <org/app-name>
+
+  - Format: org/app-name, find your organizations with \`fly orgs\`.
+  - App name will be lowercased, accepted characters: [a-z0-9-_.]`,
+  action: async () => {
+    const opts = root.getOptions(false)
+
+    try {
+      let name = null;
+      if (opts.name) {
+        if (!opts.name.match(fullAppMatch))
+          return console.log("App name, if provided, needs to match regex:", fullAppMatch)
+        name = opts.name
+      }
+      const res = await API.post(`/api/v1/apps`, { data: { attributes: { name: name } } })
+      processResponse(res, (res: any) => {
+        console.log(`App ${res.data.data.attributes.name} created!`)
+        if (existsSync(".fly.yml"))
+          console.log(`Add it to your .fly.yml like: \`app: ${res.data.data.attributes.name}\``)
+        else {
+          writeFileSync(".fly.yml", `app: ${res.data.data.attributes.name}`)
+          console.log("Created a .fly.yml for you.")
+        }
+      })
+    } catch (e) {
+      if (e.response)
+        return console.log(e.response.data)
+      console.error(e.stack)
+      throw e
+    }
+  }
+}])

--- a/src/cmd/apps.ts
+++ b/src/cmd/apps.ts
@@ -1,71 +1,71 @@
-import { root, fullAppMatch } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-import { existsSync, writeFileSync } from 'fs';
-
-const Table = require('cli-table2')
-
-interface AppsOptions { }
-interface AppsArgs { }
-
-const apps = root
-  .subCommand<AppsOptions, AppsArgs>("apps")
-  .description("Manage Fly apps.")
-  .action(async (opts, args, rest) => {
-    try {
-      const res = await API.get("/api/v1/apps")
-      processResponse(res, (res: any) => {
-        const table = new Table({
-          style: { head: [] },
-          head: ['org', 'name', 'version']
-        })
-        table.push(...res.data.data.map((a: any) =>
-          [a.attributes.org, a.attributes.name, a.attributes.version]
-        ))
-        console.log(table.toString())
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
-
-interface AppsCreateOptions { }
-interface AppsCreateArgs {
-  name?: string
-}
-
-apps
-  .subCommand<AppsCreateOptions, AppsCreateArgs>("create [name]")
-  .description("Create a Fly app.")
-  .usage(`fly apps create <org/app-name>
-
-  - Format: org/app-name, find your organizations with \`fly orgs\`.
-  - App name will be lowercased, accepted characters: [a-z0-9-_.]`)
-  .action(async (opts, args, rest) => {
-    try {
-      let name = null;
-      if (args.name) {
-        if (!args.name.match(fullAppMatch))
-          return console.log("App name, if provided, needs to match regex:", fullAppMatch)
-        name = args.name
-      }
-      const res = await API.post(`/api/v1/apps`, { data: { attributes: { name: name } } })
-      processResponse(res, (res: any) => {
-        console.log(`App ${res.data.data.attributes.name} created!`)
-        if (existsSync(".fly.yml"))
-          console.log(`Add it to your .fly.yml like: \`app: ${res.data.data.attributes.name}\``)
-        else {
-          writeFileSync(".fly.yml", `app: ${res.data.data.attributes.name}`)
-          console.log("Created a .fly.yml for you.")
-        }
-      })
-    } catch (e) {
-      if (e.response)
-        return console.log(e.response.data)
-      console.error(e.stack)
-      throw e
-    }
-  })
+// import { root, fullAppMatch } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+// import { existsSync, writeFileSync } from 'fs';
+//
+// const Table = require('cli-table2')
+//
+// interface AppsOptions { }
+// interface AppsArgs { }
+//
+// const apps = root
+//   .subCommand<AppsOptions, AppsArgs>("apps")
+//   .description("Manage Fly apps.")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const res = await API.get("/api/v1/apps")
+//       processResponse(res, (res: any) => {
+//         const table = new Table({
+//           style: { head: [] },
+//           head: ['org', 'name', 'version']
+//         })
+//         table.push(...res.data.data.map((a: any) =>
+//           [a.attributes.org, a.attributes.name, a.attributes.version]
+//         ))
+//         console.log(table.toString())
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })
+//
+// interface AppsCreateOptions { }
+// interface AppsCreateArgs {
+//   name?: string
+// }
+//
+// apps
+//   .subCommand<AppsCreateOptions, AppsCreateArgs>("create [name]")
+//   .description("Create a Fly app.")
+//   .usage(`fly apps create <org/app-name>
+//
+//   - Format: org/app-name, find your organizations with \`fly orgs\`.
+//   - App name will be lowercased, accepted characters: [a-z0-9-_.]`)
+//   .action(async (opts, args, rest) => {
+//     try {
+//       let name = null;
+//       if (args.name) {
+//         if (!args.name.match(fullAppMatch))
+//           return console.log("App name, if provided, needs to match regex:", fullAppMatch)
+//         name = args.name
+//       }
+//       const res = await API.post(`/api/v1/apps`, { data: { attributes: { name: name } } })
+//       processResponse(res, (res: any) => {
+//         console.log(`App ${res.data.data.attributes.name} created!`)
+//         if (existsSync(".fly.yml"))
+//           console.log(`Add it to your .fly.yml like: \`app: ${res.data.data.attributes.name}\``)
+//         else {
+//           writeFileSync(".fly.yml", `app: ${res.data.data.attributes.name}`)
+//           console.log("Created a .fly.yml for you.")
+//         }
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         return console.log(e.response.data)
+//       console.error(e.stack)
+//       throw e
+//     }
+//   })

--- a/src/cmd/apps.ts
+++ b/src/cmd/apps.ts
@@ -36,6 +36,7 @@ root.add([{
 }, {
   type: COMMAND,
   name: 'create',
+  dontShow: true,
   takesArguments: true,
   mapTo: 'name',
   description: "Create a Fly app.",

--- a/src/cmd/argTypes.ts
+++ b/src/cmd/argTypes.ts
@@ -1,0 +1,2 @@
+export const COMMAND = 'COMMAND'
+export const OPTION = 'OPTION'

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -1,80 +1,80 @@
-import { root, getAppName } from './root'
-import { API } from './api'
-import { getLocalRelease } from '../utils/local'
-import { processResponse } from '../utils/cli'
-
-import log from '../log'
-
-import * as tar from 'tar-fs'
-import * as glob from 'glob'
-import { Readable } from 'stream';
-import { createWriteStream, readFileSync, existsSync } from 'fs';
-import { createHash } from 'crypto';
-
-import * as pako from 'pako'
-import { AxiosResponse } from 'axios';
-
-export interface DeployOptions { }
-export interface DeployArgs { }
-
-root
-  .subCommand<DeployOptions, DeployArgs>("deploy")
-  .description("Deploy your local Fly app.")
-  .action((opts, args, rest) => {
-    const { buildApp } = require('../utils/build')
-    const appName = getAppName("production")
-    console.log("Deploying", appName)
-    const cwd = process.cwd()
-
-    const release = getLocalRelease(cwd, "production", { noWatch: true })
-
-    buildApp(cwd, { watch: false, uglify: true }, async (err: Error, source: string, hash: string, sourceMap: string) => {
-      try {
-        const entries = [
-          '.fly.yml',
-          ...glob.sync('.fly/*/**.{js,json}'),
-          ...release.files
-        ].filter((f) => existsSync(f))
-
-        const res = await new Promise<AxiosResponse<any>>((resolve, reject) => {
-          const packer: Readable = tar.pack('.', {
-            entries: entries,
-            dereference: true,
-            finish: function () {
-              log.debug("Finished packing.")
-              const buf = readFileSync(".fly/bundle.tar")
-              console.log(`Bundle size: ${buf.byteLength / (1024 * 1024)}MB`)
-              const gz = pako.gzip(buf)
-              console.log(`Bundle compressed size: ${gz.byteLength / (1024 * 1024)}MB`)
-              const hash = createHash("sha1") // we need to verify the upload is :+1:
-              hash.update(buf)
-
-              const res = API.post(`/api/v1/apps/${appName}/releases`, gz, {
-                params: {
-                  sha1: hash.digest('hex')
-                },
-                headers: {
-                  'Content-Type': 'application/x-tar',
-                  'Content-Length': gz.byteLength,
-                  'Content-Encoding': 'gzip'
-                },
-                maxContentLength: 100 * 1024 * 1024,
-                timeout: 120 * 1000
-              }).then(resolve).catch(reject)
-            },
-          }).pipe(createWriteStream(".fly/bundle.tar"))
-        })
-
-        processResponse(res, (res: any) => {
-          console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
-        })
-
-      } catch (e) {
-        if (e.response)
-          console.log(e.response.data)
-        else {
-          throw e
-        }
-      }
-    })
-  })
+// import { root, getAppName } from './root'
+// import { API } from './api'
+// import { getLocalRelease } from '../utils/local'
+// import { processResponse } from '../utils/cli'
+//
+// import log from '../log'
+//
+// import * as tar from 'tar-fs'
+// import * as glob from 'glob'
+// import { Readable } from 'stream';
+// import { createWriteStream, readFileSync, existsSync } from 'fs';
+// import { createHash } from 'crypto';
+//
+// import * as pako from 'pako'
+// import { AxiosResponse } from 'axios';
+//
+// export interface DeployOptions { }
+// export interface DeployArgs { }
+//
+// root
+//   .subCommand<DeployOptions, DeployArgs>("deploy")
+//   .description("Deploy your local Fly app.")
+//   .action((opts, args, rest) => {
+//     const { buildApp } = require('../utils/build')
+//     const appName = getAppName("production")
+//     console.log("Deploying", appName)
+//     const cwd = process.cwd()
+//
+//     const release = getLocalRelease(cwd, "production", { noWatch: true })
+//
+//     buildApp(cwd, { watch: false, uglify: true }, async (err: Error, source: string, hash: string, sourceMap: string) => {
+//       try {
+//         const entries = [
+//           '.fly.yml',
+//           ...glob.sync('.fly/*/**.{js,json}'),
+//           ...release.files
+//         ].filter((f) => existsSync(f))
+//
+//         const res = await new Promise<AxiosResponse<any>>((resolve, reject) => {
+//           const packer: Readable = tar.pack('.', {
+//             entries: entries,
+//             dereference: true,
+//             finish: function () {
+//               log.debug("Finished packing.")
+//               const buf = readFileSync(".fly/bundle.tar")
+//               console.log(`Bundle size: ${buf.byteLength / (1024 * 1024)}MB`)
+//               const gz = pako.gzip(buf)
+//               console.log(`Bundle compressed size: ${gz.byteLength / (1024 * 1024)}MB`)
+//               const hash = createHash("sha1") // we need to verify the upload is :+1:
+//               hash.update(buf)
+//
+//               const res = API.post(`/api/v1/apps/${appName}/releases`, gz, {
+//                 params: {
+//                   sha1: hash.digest('hex')
+//                 },
+//                 headers: {
+//                   'Content-Type': 'application/x-tar',
+//                   'Content-Length': gz.byteLength,
+//                   'Content-Encoding': 'gzip'
+//                 },
+//                 maxContentLength: 100 * 1024 * 1024,
+//                 timeout: 120 * 1000
+//               }).then(resolve).catch(reject)
+//             },
+//           }).pipe(createWriteStream(".fly/bundle.tar"))
+//         })
+//
+//         processResponse(res, (res: any) => {
+//           console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
+//         })
+//
+//       } catch (e) {
+//         if (e.response)
+//           console.log(e.response.data)
+//         else {
+//           throw e
+//         }
+//       }
+//     })
+//   })

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -1,80 +1,83 @@
-// import { root, getAppName } from './root'
-// import { API } from './api'
-// import { getLocalRelease } from '../utils/local'
-// import { processResponse } from '../utils/cli'
-//
-// import log from '../log'
-//
-// import * as tar from 'tar-fs'
-// import * as glob from 'glob'
-// import { Readable } from 'stream';
-// import { createWriteStream, readFileSync, existsSync } from 'fs';
-// import { createHash } from 'crypto';
-//
-// import * as pako from 'pako'
-// import { AxiosResponse } from 'axios';
-//
-// export interface DeployOptions { }
-// export interface DeployArgs { }
-//
-// root
-//   .subCommand<DeployOptions, DeployArgs>("deploy")
-//   .description("Deploy your local Fly app.")
-//   .action((opts, args, rest) => {
-//     const { buildApp } = require('../utils/build')
-//     const appName = getAppName("production")
-//     console.log("Deploying", appName)
-//     const cwd = process.cwd()
-//
-//     const release = getLocalRelease(cwd, "production", { noWatch: true })
-//
-//     buildApp(cwd, { watch: false, uglify: true }, async (err: Error, source: string, hash: string, sourceMap: string) => {
-//       try {
-//         const entries = [
-//           '.fly.yml',
-//           ...glob.sync('.fly/*/**.{js,json}'),
-//           ...release.files
-//         ].filter((f) => existsSync(f))
-//
-//         const res = await new Promise<AxiosResponse<any>>((resolve, reject) => {
-//           const packer: Readable = tar.pack('.', {
-//             entries: entries,
-//             dereference: true,
-//             finish: function () {
-//               log.debug("Finished packing.")
-//               const buf = readFileSync(".fly/bundle.tar")
-//               console.log(`Bundle size: ${buf.byteLength / (1024 * 1024)}MB`)
-//               const gz = pako.gzip(buf)
-//               console.log(`Bundle compressed size: ${gz.byteLength / (1024 * 1024)}MB`)
-//               const hash = createHash("sha1") // we need to verify the upload is :+1:
-//               hash.update(buf)
-//
-//               const res = API.post(`/api/v1/apps/${appName}/releases`, gz, {
-//                 params: {
-//                   sha1: hash.digest('hex')
-//                 },
-//                 headers: {
-//                   'Content-Type': 'application/x-tar',
-//                   'Content-Length': gz.byteLength,
-//                   'Content-Encoding': 'gzip'
-//                 },
-//                 maxContentLength: 100 * 1024 * 1024,
-//                 timeout: 120 * 1000
-//               }).then(resolve).catch(reject)
-//             },
-//           }).pipe(createWriteStream(".fly/bundle.tar"))
-//         })
-//
-//         processResponse(res, (res: any) => {
-//           console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
-//         })
-//
-//       } catch (e) {
-//         if (e.response)
-//           console.log(e.response.data)
-//         else {
-//           throw e
-//         }
-//       }
-//     })
-//   })
+import { root, getAppName } from './root'
+import { API } from './api'
+import { getLocalRelease } from '../utils/local'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+import log from '../log'
+
+import * as tar from 'tar-fs'
+import * as glob from 'glob'
+import { Readable } from 'stream';
+import { createWriteStream, readFileSync, existsSync } from 'fs';
+import { createHash } from 'crypto';
+
+import * as pako from 'pako'
+import { AxiosResponse } from 'axios';
+
+export interface DeployOptions { }
+export interface DeployArgs { }
+
+root.add([{
+  type: COMMAND,
+  name: 'deploy',
+  description: "Deploy your local Fly app.",
+  action: () => {
+    const { buildApp } = require('../utils/build')
+    const appName = getAppName("production")
+    console.log("Deploying", appName)
+    const cwd = process.cwd()
+
+    const release = getLocalRelease(cwd, "production", { noWatch: true })
+
+    buildApp(cwd, { watch: false, uglify: true }, async (err: Error, source: string, hash: string, sourceMap: string) => {
+      try {
+        const entries = [
+          '.fly.yml',
+          ...glob.sync('.fly/*/**.{js,json}'),
+          ...release.files
+        ].filter((f) => existsSync(f))
+
+        const res = await new Promise<AxiosResponse<any>>((resolve, reject) => {
+          const packer: Readable = tar.pack('.', {
+            entries: entries,
+            dereference: true,
+            finish: function () {
+              log.debug("Finished packing.")
+              const buf = readFileSync(".fly/bundle.tar")
+              console.log(`Bundle size: ${buf.byteLength / (1024 * 1024)}MB`)
+              const gz = pako.gzip(buf)
+              console.log(`Bundle compressed size: ${gz.byteLength / (1024 * 1024)}MB`)
+              const hash = createHash("sha1") // we need to verify the upload is :+1:
+              hash.update(buf)
+
+              const res = API.post(`/api/v1/apps/${appName}/releases`, gz, {
+                params: {
+                  sha1: hash.digest('hex')
+                },
+                headers: {
+                  'Content-Type': 'application/x-tar',
+                  'Content-Length': gz.byteLength,
+                  'Content-Encoding': 'gzip'
+                },
+                maxContentLength: 100 * 1024 * 1024,
+                timeout: 120 * 1000
+              }).then(resolve).catch(reject)
+            },
+          }).pipe(createWriteStream(".fly/bundle.tar"))
+        })
+
+        processResponse(res, (res: any) => {
+          console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
+        })
+
+      } catch (e) {
+        if (e.response)
+          console.log(e.response.data)
+        else {
+          throw e
+        }
+      }
+    })
+  }
+}])

--- a/src/cmd/fetch.ts
+++ b/src/cmd/fetch.ts
@@ -1,24 +1,24 @@
-import { root, getAppName } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-
-export interface FetchOptions { }
-export interface FetchArgs { }
-
-root
-  .subCommand<FetchOptions, FetchArgs>("fetch")
-  .description("Fetch your Fly app locally.")
-  .action(async (opts, args, rest) => {
-    try {
-      const appName = getAppName()
-      const res = await API.get(`/api/v1/apps/${appName}/source`)
-      processResponse(res, (res: any) => {
-        console.log(res.data.data.attributes.source)
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
+// import { root, getAppName } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+//
+// export interface FetchOptions { }
+// export interface FetchArgs { }
+//
+// root
+//   .subCommand<FetchOptions, FetchArgs>("fetch")
+//   .description("Fetch your Fly app locally.")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const appName = getAppName()
+//       const res = await API.get(`/api/v1/apps/${appName}/source`)
+//       processResponse(res, (res: any) => {
+//         console.log(res.data.data.attributes.source)
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })

--- a/src/cmd/fetch.ts
+++ b/src/cmd/fetch.ts
@@ -1,24 +1,27 @@
-// import { root, getAppName } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-//
-// export interface FetchOptions { }
-// export interface FetchArgs { }
-//
-// root
-//   .subCommand<FetchOptions, FetchArgs>("fetch")
-//   .description("Fetch your Fly app locally.")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const appName = getAppName()
-//       const res = await API.get(`/api/v1/apps/${appName}/source`)
-//       processResponse(res, (res: any) => {
-//         console.log(res.data.data.attributes.source)
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
+import { root, getAppName } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+export interface FetchOptions { }
+export interface FetchArgs { }
+
+root.add([{
+  type: COMMAND,
+  name: 'fetch',
+  description: "Fetch your Fly app locally.",
+  action: async () => {
+    try {
+      const appName = getAppName()
+      const res = await API.get(`/api/v1/apps/${appName}/source`)
+      processResponse(res, (res: any) => {
+        console.log(res.data.data.attributes.source)
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+}])

--- a/src/cmd/hostnames.ts
+++ b/src/cmd/hostnames.ts
@@ -33,6 +33,7 @@ root.add([{
   name: 'add',
   dontShow: true,
   takesArguments: true,
+  respondsTo: 'hostnames',
   mapTo: 'hostname',
   description: "Add a hostname to your fly app.",
   action: async () => {

--- a/src/cmd/hostnames.ts
+++ b/src/cmd/hostnames.ts
@@ -1,51 +1,51 @@
-// import { root, getAppName } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-//
-// interface HostnamesOptions { }
-// interface HostnamesArgs { }
-//
-// const hostnames = root
-//   .subCommand<HostnamesOptions, HostnamesArgs>("hostnames")
-//   .description("Manage Fly app's hostnames.")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const res = await API.get(`/api/v1/apps/${getAppName()}/hostnames`)
-//       processResponse(res, (res: any) => {
-//         if (!res.data.data || res.data.data.length === 0)
-//           return console.log("No hostnames configured, use `fly hostnames add` to add one.")
-//         for (let h of res.data.data) {
-//           console.log(h.attributes.hostname)
-//         }
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
-//
-// interface HostnamesAddOptions { }
-// interface HostnamesAddArgs {
-//   hostname: string
-// }
-//
-// hostnames
-//   .subCommand<HostnamesAddOptions, HostnamesAddArgs>("add <hostname>")
-//   .description("Add a hostname to your fly app.")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const res = await API.post(`/api/v1/apps/${getAppName()}/hostnames`, { data: { attributes: { hostname: args.hostname } } })
-//       processResponse(res, (res: any) => {
-//         console.log(`Successfully added hostname ${args.hostname}`)
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
-//
-//
+import { root, getAppName } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+interface HostnamesOptions { }
+interface HostnamesArgs { }
+
+root.add([{
+  type: COMMAND,
+  name: 'hostnames',
+  description: "Manage Fly app's hostnames.",
+  action: async () => {
+    try {
+      const res = await API.get(`/api/v1/apps/${getAppName()}/hostnames`)
+      processResponse(res, (res: any) => {
+        if (!res.data.data || res.data.data.length === 0)
+          return console.log("No hostnames configured, use `fly hostnames add` to add one.")
+        for (let h of res.data.data) {
+          console.log(h.attributes.hostname)
+        }
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+},
+{
+  type: COMMAND,
+  name: 'add',
+  takesArguments: true,
+  mapTo: 'hostname',
+  description: "Add a hostname to your fly app.",
+  action: async () => {
+    const opts = root.getOptions(false)
+    try {
+      const res = await API.post(`/api/v1/apps/${getAppName()}/hostnames`, { data: { attributes: { hostname: opts.hostname } } })
+      processResponse(res, (res: any) => {
+        console.log(`Successfully added hostname ${opts.hostname}`)
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+}])

--- a/src/cmd/hostnames.ts
+++ b/src/cmd/hostnames.ts
@@ -31,6 +31,7 @@ root.add([{
 {
   type: COMMAND,
   name: 'add',
+  dontShow: true,
   takesArguments: true,
   mapTo: 'hostname',
   description: "Add a hostname to your fly app.",

--- a/src/cmd/hostnames.ts
+++ b/src/cmd/hostnames.ts
@@ -1,51 +1,51 @@
-import { root, getAppName } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-
-interface HostnamesOptions { }
-interface HostnamesArgs { }
-
-const hostnames = root
-  .subCommand<HostnamesOptions, HostnamesArgs>("hostnames")
-  .description("Manage Fly app's hostnames.")
-  .action(async (opts, args, rest) => {
-    try {
-      const res = await API.get(`/api/v1/apps/${getAppName()}/hostnames`)
-      processResponse(res, (res: any) => {
-        if (!res.data.data || res.data.data.length === 0)
-          return console.log("No hostnames configured, use `fly hostnames add` to add one.")
-        for (let h of res.data.data) {
-          console.log(h.attributes.hostname)
-        }
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
-
-interface HostnamesAddOptions { }
-interface HostnamesAddArgs {
-  hostname: string
-}
-
-hostnames
-  .subCommand<HostnamesAddOptions, HostnamesAddArgs>("add <hostname>")
-  .description("Add a hostname to your fly app.")
-  .action(async (opts, args, rest) => {
-    try {
-      const res = await API.post(`/api/v1/apps/${getAppName()}/hostnames`, { data: { attributes: { hostname: args.hostname } } })
-      processResponse(res, (res: any) => {
-        console.log(`Successfully added hostname ${args.hostname}`)
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
-
-
+// import { root, getAppName } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+//
+// interface HostnamesOptions { }
+// interface HostnamesArgs { }
+//
+// const hostnames = root
+//   .subCommand<HostnamesOptions, HostnamesArgs>("hostnames")
+//   .description("Manage Fly app's hostnames.")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const res = await API.get(`/api/v1/apps/${getAppName()}/hostnames`)
+//       processResponse(res, (res: any) => {
+//         if (!res.data.data || res.data.data.length === 0)
+//           return console.log("No hostnames configured, use `fly hostnames add` to add one.")
+//         for (let h of res.data.data) {
+//           console.log(h.attributes.hostname)
+//         }
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })
+//
+// interface HostnamesAddOptions { }
+// interface HostnamesAddArgs {
+//   hostname: string
+// }
+//
+// hostnames
+//   .subCommand<HostnamesAddOptions, HostnamesAddArgs>("add <hostname>")
+//   .description("Add a hostname to your fly app.")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const res = await API.post(`/api/v1/apps/${getAppName()}/hostnames`, { data: { attributes: { hostname: args.hostname } } })
+//       processResponse(res, (res: any) => {
+//         console.log(`Successfully added hostname ${args.hostname}`)
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })
+//
+//

--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 
-import { root } from './root';
+import { root, getToken } from './root';
 
-require("./apps");
-require("./orgs");
-require("./deploy");
-require("./releases");
-require("./secrets");
-require("./test");
+// require("./apps");
+// require("./orgs");
+// require("./deploy");
+// require("./releases");
+// require("./secrets");
+// require("./test");
 require("./server");
-require("./hostnames");
-require("./login");
-require("./fetch");
-require("./logs");
+// require("./hostnames");
+// require("./login");
+// require("./fetch");
+// require("./logs");
 
 var SegfaultHandler = require('segfault-handler');
 SegfaultHandler.registerHandler("crash.log");
@@ -20,14 +20,4 @@ SegfaultHandler.registerHandler("crash.log");
 process.on('uncaughtException', err => console.error('uncaught exception:', err.stack));
 process.on('unhandledRejection', err => console.error('unhandled rejection:', err.stack));
 
-import { exec } from "commandpost";
-
-exec(root, process.argv)
-  .catch(err => {
-    if (err instanceof Error) {
-      console.error(err.stack);
-    } else {
-      console.error(err);
-    }
-    process.exit(1);
-  });
+root.getOptions(true)

--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -6,7 +6,7 @@ import { root, getToken } from './root';
 // require("./orgs");
 // require("./deploy");
 // require("./releases");
-// require("./secrets");
+require("./secrets");
 require("./test");
 require("./server");
 // require("./hostnames");

--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -7,7 +7,7 @@ import { root, getToken } from './root';
 // require("./deploy");
 // require("./releases");
 // require("./secrets");
-// require("./test");
+require("./test");
 require("./server");
 // require("./hostnames");
 // require("./login");

--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -2,17 +2,17 @@
 
 import { root, getToken } from './root';
 
-// require("./apps");
-// require("./orgs");
-// require("./deploy");
-// require("./releases");
+require("./apps");
+require("./orgs");
+require("./deploy");
+require("./releases");
 require("./secrets");
 require("./test");
 require("./server");
-// require("./hostnames");
-// require("./login");
-// require("./fetch");
-// require("./logs");
+require("./hostnames");
+require("./login");
+require("./fetch");
+require("./logs");
 
 var SegfaultHandler = require('segfault-handler');
 SegfaultHandler.registerHandler("crash.log");

--- a/src/cmd/login.ts
+++ b/src/cmd/login.ts
@@ -1,36 +1,38 @@
-// import { root, homeConfigPath } from './root'
-// import axios from 'axios'
-// import { processResponse } from '../utils/cli'
-//
-//
-// const promptly = require('promptly')
-//
-// import path = require('path')
-// import fs = require('fs-extra')
-// import YAML = require('js-yaml')
-//
-// const baseURL = process.env.FLY_BASE_URL || "https://fly.io"
-//
-// root
-//   .subCommand<any, any>("login")
-//   .description("Login to Fly and save credentials locally.")
-//   .action(async (opts, args, rest) => {
-//     const email = await promptly.prompt("Email: ")
-//     const password = await promptly.password("Password: ")
-//     const otp = await promptly.prompt("2FA code (if any): ", { default: "n/a", retry: false })
-//     try {
-//
-//       const res = await axios.post(`${baseURL}/api/v1/sessions`, { data: { attributes: { email, password, otp } } })
-//       processResponse(res, (res: any) => {
-//         const homepath = homeConfigPath()
-//         const credspath = path.join(homepath, "credentials.yml")
-//         fs.writeFileSync(credspath, YAML.dump({ access_token: res.data.data.attributes.access_token }))
-//         console.log("Wrote credentials at:", credspath)
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
+import { root, homeConfigPath } from './root'
+import axios from 'axios'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+const promptly = require('promptly')
+
+import path = require('path')
+import fs = require('fs-extra')
+import YAML = require('js-yaml')
+
+const baseURL = process.env.FLY_BASE_URL || "https://fly.io"
+
+root.add([{
+  type: COMMAND,
+  name: 'login',
+  description: "Login to Fly and save credentials locally.",
+  action: async () => {
+    const email = await promptly.prompt("Email: ")
+    const password = await promptly.password("Password: ")
+    const otp = await promptly.prompt("2FA code (if any): ", { default: "n/a", retry: false })
+    try {
+
+      const res = await axios.post(`${baseURL}/api/v1/sessions`, { data: { attributes: { email, password, otp } } })
+      processResponse(res, (res: any) => {
+        const homepath = homeConfigPath()
+        const credspath = path.join(homepath, "credentials.yml")
+        fs.writeFileSync(credspath, YAML.dump({ access_token: res.data.data.attributes.access_token }))
+        console.log("Wrote credentials at:", credspath)
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+}])

--- a/src/cmd/login.ts
+++ b/src/cmd/login.ts
@@ -1,36 +1,36 @@
-import { root, homeConfigPath } from './root'
-import axios from 'axios'
-import { processResponse } from '../utils/cli'
-
-
-const promptly = require('promptly')
-
-import path = require('path')
-import fs = require('fs-extra')
-import YAML = require('js-yaml')
-
-const baseURL = process.env.FLY_BASE_URL || "https://fly.io"
-
-root
-  .subCommand<any, any>("login")
-  .description("Login to Fly and save credentials locally.")
-  .action(async (opts, args, rest) => {
-    const email = await promptly.prompt("Email: ")
-    const password = await promptly.password("Password: ")
-    const otp = await promptly.prompt("2FA code (if any): ", { default: "n/a", retry: false })
-    try {
-
-      const res = await axios.post(`${baseURL}/api/v1/sessions`, { data: { attributes: { email, password, otp } } })
-      processResponse(res, (res: any) => {
-        const homepath = homeConfigPath()
-        const credspath = path.join(homepath, "credentials.yml")
-        fs.writeFileSync(credspath, YAML.dump({ access_token: res.data.data.attributes.access_token }))
-        console.log("Wrote credentials at:", credspath)
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
+// import { root, homeConfigPath } from './root'
+// import axios from 'axios'
+// import { processResponse } from '../utils/cli'
+//
+//
+// const promptly = require('promptly')
+//
+// import path = require('path')
+// import fs = require('fs-extra')
+// import YAML = require('js-yaml')
+//
+// const baseURL = process.env.FLY_BASE_URL || "https://fly.io"
+//
+// root
+//   .subCommand<any, any>("login")
+//   .description("Login to Fly and save credentials locally.")
+//   .action(async (opts, args, rest) => {
+//     const email = await promptly.prompt("Email: ")
+//     const password = await promptly.password("Password: ")
+//     const otp = await promptly.prompt("2FA code (if any): ", { default: "n/a", retry: false })
+//     try {
+//
+//       const res = await axios.post(`${baseURL}/api/v1/sessions`, { data: { attributes: { email, password, otp } } })
+//       processResponse(res, (res: any) => {
+//         const homepath = homeConfigPath()
+//         const credspath = path.join(homepath, "credentials.yml")
+//         fs.writeFileSync(credspath, YAML.dump({ access_token: res.data.data.attributes.access_token }))
+//         console.log("Wrote credentials at:", credspath)
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })

--- a/src/cmd/logs.ts
+++ b/src/cmd/logs.ts
@@ -1,85 +1,88 @@
-// import { root, getAppName } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-//
-// import log from '../log'
-//
-// import colors = require('ansi-colors')
-//
-// export interface LogsOptions { }
-// export interface LogsArgs { }
-//
-// root
-//   .subCommand<LogsOptions, LogsArgs>("logs")
-//   .description("Logs from your app.")
-//   .action(async (opts, args, rest) => {
-//     continuouslyGetLogs(getAppName())
-//   })
-//
-// async function continuouslyGetLogs(appName: string) {
-//   log.silly("continuously get logs for app id:", appName)
-//   let lastNextToken: string | undefined;
-//   while (true) {
-//     try {
-//       const [logs, nextToken] = await getLogs(appName, lastNextToken)
-//       lastNextToken = nextToken
-//       showLogs(logs)
-//     } catch (e) {
-//       if (e.response)
-//         processResponse(e.response)
-//       else
-//         console.log(e.stack)
-//       break;
-//     }
-//     await sleep(5000) // give it a rest!
-//   }
-// }
-//
-// const levelColorFn: { [lvl: string]: (message: string) => string } = {
-//   "info": colors.blue,
-//   "debug": colors.cyan,
-//   "error": colors.red,
-// }
-//
-// interface LogAttributes {
-//   timestamp: number
-//   level: string
-//   message: string
-//   meta: any
-// }
-//
-// interface Log {
-//   attributes: LogAttributes
-// }
-//
-// async function showLogs(logs: Log[]) {
-//   for (const l of logs) {
-//     const levelColor = levelColorFn[l.attributes.level] || colors.white
-//     console.log(`${colors.dim(new Date(l.attributes.timestamp).toISOString())} [${levelColor(l.attributes.level)}] ${l.attributes.message}`)
-//   }
-// }
-//
-// async function getLogs(appName: string, nextToken?: string): Promise<[any[], string | undefined]> {
-//   const res = await API.get(`/api/v1/apps/${appName}/logs`, {
-//     params: { next_token: nextToken }
-//   })
-//   if (res.data.data && res.data.meta) {
-//     return [res.data.data, res.data.meta.next_token]
-//   }
-//   // no data that we want, likely an error, continuouslyGetLogs will catch and
-//   // process errors accordingly
-//   throw new LogResponseError(res)
-// }
-//
-// function sleep(i: number) {
-//   return new Promise((res) => setTimeout(res, i))
-// }
-//
-// class LogResponseError extends Error {
-//   response: Object
-//
-//   constructor(response: Object, ...params: any[]) {
-//     super(...params)
-//     this.response = response
-//   }
-// }
+import { root, getAppName } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+import log from '../log'
+
+import colors = require('ansi-colors')
+
+export interface LogsOptions { }
+export interface LogsArgs { }
+
+root.add([{
+  type: COMMAND,
+  description: "Logs from your app.",
+  name: 'logs',
+  action: async () => {
+    continuouslyGetLogs(getAppName())
+  }
+}])
+
+async function continuouslyGetLogs(appName: string) {
+  log.silly("continuously get logs for app id:", appName)
+  let lastNextToken: string | undefined;
+  while (true) {
+    try {
+      const [logs, nextToken] = await getLogs(appName, lastNextToken)
+      lastNextToken = nextToken
+      showLogs(logs)
+    } catch (e) {
+      if (e.response)
+        processResponse(e.response)
+      else
+        console.log(e.stack)
+      break;
+    }
+    await sleep(5000) // give it a rest!
+  }
+}
+
+const levelColorFn: { [lvl: string]: (message: string) => string } = {
+  "info": colors.blue,
+  "debug": colors.cyan,
+  "error": colors.red,
+}
+
+interface LogAttributes {
+  timestamp: number
+  level: string
+  message: string
+  meta: any
+}
+
+interface Log {
+  attributes: LogAttributes
+}
+
+async function showLogs(logs: Log[]) {
+  for (const l of logs) {
+    const levelColor = levelColorFn[l.attributes.level] || colors.white
+    console.log(`${colors.dim(new Date(l.attributes.timestamp).toISOString())} [${levelColor(l.attributes.level)}] ${l.attributes.message}`)
+  }
+}
+
+async function getLogs(appName: string, nextToken?: string): Promise<[any[], string | undefined]> {
+  const res = await API.get(`/api/v1/apps/${appName}/logs`, {
+    params: { next_token: nextToken }
+  })
+  if (res.data.data && res.data.meta) {
+    return [res.data.data, res.data.meta.next_token]
+  }
+  // no data that we want, likely an error, continuouslyGetLogs will catch and
+  // process errors accordingly
+  throw new LogResponseError(res)
+}
+
+function sleep(i: number) {
+  return new Promise((res) => setTimeout(res, i))
+}
+
+class LogResponseError extends Error {
+  response: Object
+
+  constructor(response: Object, ...params: any[]) {
+    super(...params)
+    this.response = response
+  }
+}

--- a/src/cmd/logs.ts
+++ b/src/cmd/logs.ts
@@ -1,85 +1,85 @@
-import { root, getAppName } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-
-import log from '../log'
-
-import colors = require('ansi-colors')
-
-export interface LogsOptions { }
-export interface LogsArgs { }
-
-root
-  .subCommand<LogsOptions, LogsArgs>("logs")
-  .description("Logs from your app.")
-  .action(async (opts, args, rest) => {
-    continuouslyGetLogs(getAppName())
-  })
-
-async function continuouslyGetLogs(appName: string) {
-  log.silly("continuously get logs for app id:", appName)
-  let lastNextToken: string | undefined;
-  while (true) {
-    try {
-      const [logs, nextToken] = await getLogs(appName, lastNextToken)
-      lastNextToken = nextToken
-      showLogs(logs)
-    } catch (e) {
-      if (e.response)
-        processResponse(e.response)
-      else
-        console.log(e.stack)
-      break;
-    }
-    await sleep(5000) // give it a rest!
-  }
-}
-
-const levelColorFn: { [lvl: string]: (message: string) => string } = {
-  "info": colors.blue,
-  "debug": colors.cyan,
-  "error": colors.red,
-}
-
-interface LogAttributes {
-  timestamp: number
-  level: string
-  message: string
-  meta: any
-}
-
-interface Log {
-  attributes: LogAttributes
-}
-
-async function showLogs(logs: Log[]) {
-  for (const l of logs) {
-    const levelColor = levelColorFn[l.attributes.level] || colors.white
-    console.log(`${colors.dim(new Date(l.attributes.timestamp).toISOString())} [${levelColor(l.attributes.level)}] ${l.attributes.message}`)
-  }
-}
-
-async function getLogs(appName: string, nextToken?: string): Promise<[any[], string | undefined]> {
-  const res = await API.get(`/api/v1/apps/${appName}/logs`, {
-    params: { next_token: nextToken }
-  })
-  if (res.data.data && res.data.meta) {
-    return [res.data.data, res.data.meta.next_token]
-  }
-  // no data that we want, likely an error, continuouslyGetLogs will catch and
-  // process errors accordingly
-  throw new LogResponseError(res)
-}
-
-function sleep(i: number) {
-  return new Promise((res) => setTimeout(res, i))
-}
-
-class LogResponseError extends Error {
-  response: Object
-
-  constructor(response: Object, ...params: any[]) {
-    super(...params)
-    this.response = response
-  }
-}
+// import { root, getAppName } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+//
+// import log from '../log'
+//
+// import colors = require('ansi-colors')
+//
+// export interface LogsOptions { }
+// export interface LogsArgs { }
+//
+// root
+//   .subCommand<LogsOptions, LogsArgs>("logs")
+//   .description("Logs from your app.")
+//   .action(async (opts, args, rest) => {
+//     continuouslyGetLogs(getAppName())
+//   })
+//
+// async function continuouslyGetLogs(appName: string) {
+//   log.silly("continuously get logs for app id:", appName)
+//   let lastNextToken: string | undefined;
+//   while (true) {
+//     try {
+//       const [logs, nextToken] = await getLogs(appName, lastNextToken)
+//       lastNextToken = nextToken
+//       showLogs(logs)
+//     } catch (e) {
+//       if (e.response)
+//         processResponse(e.response)
+//       else
+//         console.log(e.stack)
+//       break;
+//     }
+//     await sleep(5000) // give it a rest!
+//   }
+// }
+//
+// const levelColorFn: { [lvl: string]: (message: string) => string } = {
+//   "info": colors.blue,
+//   "debug": colors.cyan,
+//   "error": colors.red,
+// }
+//
+// interface LogAttributes {
+//   timestamp: number
+//   level: string
+//   message: string
+//   meta: any
+// }
+//
+// interface Log {
+//   attributes: LogAttributes
+// }
+//
+// async function showLogs(logs: Log[]) {
+//   for (const l of logs) {
+//     const levelColor = levelColorFn[l.attributes.level] || colors.white
+//     console.log(`${colors.dim(new Date(l.attributes.timestamp).toISOString())} [${levelColor(l.attributes.level)}] ${l.attributes.message}`)
+//   }
+// }
+//
+// async function getLogs(appName: string, nextToken?: string): Promise<[any[], string | undefined]> {
+//   const res = await API.get(`/api/v1/apps/${appName}/logs`, {
+//     params: { next_token: nextToken }
+//   })
+//   if (res.data.data && res.data.meta) {
+//     return [res.data.data, res.data.meta.next_token]
+//   }
+//   // no data that we want, likely an error, continuouslyGetLogs will catch and
+//   // process errors accordingly
+//   throw new LogResponseError(res)
+// }
+//
+// function sleep(i: number) {
+//   return new Promise((res) => setTimeout(res, i))
+// }
+//
+// class LogResponseError extends Error {
+//   response: Object
+//
+//   constructor(response: Object, ...params: any[]) {
+//     super(...params)
+//     this.response = response
+//   }
+// }

--- a/src/cmd/orgs.ts
+++ b/src/cmd/orgs.ts
@@ -1,21 +1,21 @@
-import { root } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-
-root
-  .subCommand<any, any>("orgs")
-  .description("Manage Fly orgs.")
-  .action(async (opts, args, rest) => {
-    try {
-      const res = await API.get(`/api/v1/orgs`)
-      processResponse(res, (res: any) => {
-        for (let org of res.data.data)
-          console.log(org.id)
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
+// import { root } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+//
+// root
+//   .subCommand<any, any>("orgs")
+//   .description("Manage Fly orgs.")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const res = await API.get(`/api/v1/orgs`)
+//       processResponse(res, (res: any) => {
+//         for (let org of res.data.data)
+//           console.log(org.id)
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })

--- a/src/cmd/orgs.ts
+++ b/src/cmd/orgs.ts
@@ -1,21 +1,24 @@
-// import { root } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-//
-// root
-//   .subCommand<any, any>("orgs")
-//   .description("Manage Fly orgs.")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const res = await API.get(`/api/v1/orgs`)
-//       processResponse(res, (res: any) => {
-//         for (let org of res.data.data)
-//           console.log(org.id)
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
+import { root } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+root.add([{
+  type: COMMAND,
+  name: 'orgs',
+  description: "Manage Fly orgs.",
+  action: async () => {
+    try {
+      const res = await API.get(`/api/v1/orgs`)
+      processResponse(res, (res: any) => {
+        for (let org of res.data.data)
+          console.log(org.id)
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+}])

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -104,7 +104,7 @@ class Parser {
   }
 
   private showOption(obj:any) {
-    console.log(`\t - ${obj.name} (${'--' + obj.name}, ${'-' + obj.name.charAt(0)}): ${obj.description || ''}`)
+    console.log(`\t - ${obj.name} (${'--' + obj.name}, ${'-' + obj.name.charAt(0)}) ${obj.showParams || ''}: ${obj.description || ''}`)
     if (obj.useage) console.log(`\t \t Usage: ${obj.useage}`)
   }
 

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -25,6 +25,7 @@ class Parser {
   * @param mapTo [optional] the name of the object returned from getOptions
   * @param description [optional] description of the command or option
   * @param usage [optional] the useage of a particular command or option
+  * @param takesArguments [optional] allows commands to take arguments
   */
   add(obj:any[]) {
     this.objs = [...this.objs, ...obj]

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -36,6 +36,7 @@ class Parser {
   * @property bool [optional] makes the option not take any value
   * @property dontShow [optional] does not show this option or command in usage/help
   * @property showParams [optional] displays this as parameters the option can take
+  * @property respondsTo [optional] this option will only be set if the command it responds to is also set
   */
   add(obj:any[]) {
     this.objs = [...this.objs, ...obj]
@@ -70,9 +71,14 @@ class Parser {
           !option.bool
         ) {
           argPos++
+          if (
+            command &&
+            option.respondsTo &&
+            option.respondsTo !== command.name
+          ) throw Error (`Option ${option.name} does not work with command ${command.name}`)
           this.found[option.mapTo || option.name] = argv[argPos]
         }
-        if (exicute && option.action) command = option.action
+        if (exicute && option.action) command = option
         if (option.bool) this.found[option.mapTo || option.name] = true
         argPos++
       } else {
@@ -80,7 +86,7 @@ class Parser {
       }
     }
 
-    if (command) command()
+    if (command) command.action()
     return this.found
   }
 

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -35,6 +35,7 @@ class Parser {
   * @property takesArguments [optional] allows commands to take arguments
   * @property bool [optional] makes the option not take any value
   * @property dontShow [optional] does not show this option or command in usage/help
+  * @property showParams [optional] displays this as parameters the option can take
   */
   add(obj:any[]) {
     this.objs = [...this.objs, ...obj]

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -49,11 +49,8 @@ class Parser {
     while (argPos < argv.length) {
       let option
       for (let i = 0; i < this.objs.length; i++) {
-        console.log('looking for', argv[argPos])
-        console.log('looking on option', this.objs[i].name)
         if (this.equalsName(argv[argPos], this.objs[i], this.objs[i].type === COMMAND)) {
           option = this.objs[i]
-          console.log('found option', option)
           break
         }
       }
@@ -70,7 +67,7 @@ class Parser {
         throw Error ('could not find option: ' + argv[argPos])
       }
     }
-    console.log('found', this.found)
+
     //we should never get here, but better safe than sorry
     if (command) command()
     return this.found

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -47,7 +47,6 @@ class Parser {
     if (this.found) return this.found
 
     const argv = this.argv || process.argv
-    console.log('called with args', argv)
     if (argv.indexOf('--help') >= 0 || argv.indexOf('-h') >= 0 || argv.length < 3) {
       this.displayHelp()
       return {}
@@ -86,7 +85,6 @@ class Parser {
       }
     }
 
-    console.log('found', this.found)
     if (exicute && command) command.action()
     return this.found
   }

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -115,15 +115,3 @@ class Parser {
 }
 
 export default Parser
-
-
-// if (this.objs[i].accepts === 1) {
-//   found[this.objs[i].name] = argv[argPos]
-// } else {
-//   found[this.objs[i].name] = []
-//   while (argPos < argv.length && argv[argPos].charAt(0) !== '-') {
-//     found[this.objs[i].name].push(argv[argPos])
-//     argPos++
-//   }
-//   argPos--
-// }

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -93,13 +93,13 @@ class Parser {
   private displayHelp () {
     console.log(this.description, '\n')
     console.log('\t Usage: ', this.usage, '\n')
-    console.log('\t Options: \n')
-    this.objs.forEach((obj) => {
-      if (obj.type === OPTION && !obj.dontShow) this.showOption(obj)
-    })
-    console.log('\n\t Commands: \n')
+    console.log('\t Commands: \n')
     this.objs.forEach((obj) => {
       if (obj.type === COMMAND && !obj.dontShow) this.showCommand(obj)
+    })
+    console.log('\n\t Options: \n')
+    this.objs.forEach((obj) => {
+      if (obj.type === OPTION && !obj.dontShow) this.showOption(obj)
     })
   }
 

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -3,29 +3,31 @@ import { COMMAND, OPTION } from './argTypes'
 interface Parser {
   description: string,
   objs: any[],
-  found: any
+  found: any,
+  usage: string
 }
 
 class Parser {
-  constructor (description:string, obj:any[]) {
+  constructor (description:string, usage:string, obj:any[]) {
     this.description = description
     this.objs = obj
+    this.usage = usage
   }
 
   /*
   * add takes an array of options. Options are objects in this format:
-  * @param name [required] this is the name that can the user can type to get
+  * @property name [required] this is the name that can the user can type to get
                            this option or command. for commands the user can use
                            the name and for options the user can use either
                            --the-name or -the first letter of the name eg. name:
                            from-file will be triggered by: -f || --from-file
-  * @param type [required] the type of option. this can be either COMMAND or OPTION
-  * @param action [required (for commands)] the function to be run when a
+  * @property type [required] the type of option. this can be either COMMAND or OPTION
+  * @property action [required (for commands)] the function to be run when a
                                             command is given by the user.
-  * @param mapTo [optional] the name of the object returned from getOptions
-  * @param description [optional] description of the command or option
-  * @param usage [optional] the useage of a particular command or option
-  * @param takesArguments [optional] allows commands to take arguments
+  * @property mapTo [optional] the name of the object returned from getOptions
+  * @property description [optional] description of the command or option
+  * @property usage [optional] the useage of a particular command or option
+  * @property takesArguments [optional] allows commands to take arguments
   */
   add(obj:any[]) {
     this.objs = [...this.objs, ...obj]

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -48,7 +48,8 @@ class Parser {
 
     const argv = this.argv || process.argv
     if (argv.indexOf('--help') >= 0 || argv.indexOf('-h') >= 0 || argv.length < 3) {
-      this.displayHelp()
+      if (argv.length < 4) this.displayHelp()
+      else this.displayHelpFor(this.objs.filter((item) => item.name === argv[2])[0])
       return {}
     }
 
@@ -107,6 +108,18 @@ class Parser {
     if (name === '--' + obj.name) return true
     if (name === '-' + obj.name.charAt(0)) return true
     return false
+  }
+
+  private displayHelpFor (command:any) {
+    console.log(command.description, '\n')
+    if (command.useage) console.log('\t Usage: ', command.usage, '\n')
+    console.log('\t Options: \n')
+    this.objs.forEach((obj) => {
+      if (obj.respondsTo && this.respondsTo(obj.respondsTo, command.name)) {
+        if (obj.type === COMMAND) this.showCommand(obj)
+        if (obj.type === OPTION) this.showOption(obj)
+      }
+    })
   }
 
   private displayHelp () {

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -20,7 +20,7 @@ class Parser {
     if (this.found) return this.found
 
     const argv = process.argv
-    if (argv.indexOf('--help') >= 0 || argv.indexOf('-h') >= 0) {
+    if (argv.indexOf('--help') >= 0 || argv.indexOf('-h') >= 0 || argv.length < 3) {
       this.displayHelp()
       return {}
     }
@@ -28,28 +28,30 @@ class Parser {
     let argPos = 2
     this.found = {}
     let command = null
+
     while (argPos < argv.length) {
+      let option
       for (let i = 0; i < this.objs.length; i++) {
-        console.log('found: ', this.found)
-        console.log('working on', this.objs[i].name)
-        console.log('for arg', argv[argPos])
-        if (argPos >= argv.length) {
-          console.log("ending on", argv[argPos], argPos)
-          if (command) command()
-          return this.found
-        }
+        console.log('looking for', argv[argPos])
+        console.log('looking on option', this.objs[i].name)
         if (this.equalsName(argv[argPos], this.objs[i], this.objs[i].type === COMMAND)) {
-          if (this.objs[i].type === COMMAND) {
-            if (exicute && this.objs[i].action) command = this.objs[i].action
-          } else {
-            argPos++
-            this.found[this.objs[i].name] = argv[argPos]
-          }
-          argPos++
+          option = this.objs[i]
+          console.log('found option', option)
+          break
         }
       }
+      if (option) {
+        if (option.type !== COMMAND || option.takesArguments) {
+          argPos++
+          this.found[option.name] = argv[argPos]
+        }
+        if (exicute && option.action) command = option.action
+        argPos++
+      } else {
+        throw Error ('could not find option: ' + argv[argPos])
+      }
     }
-
+    console.log('found', this.found)
     //we should never get here, but better safe than sorry
     if (command) command()
     return this.found

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -34,6 +34,7 @@ class Parser {
   * @property usage [optional] the useage of a particular command or option
   * @property takesArguments [optional] allows commands to take arguments
   * @property bool [optional] makes the option not take any value
+  * @property dontShow [optional] does not show this option or command in usage/help
   */
   add(obj:any[]) {
     this.objs = [...this.objs, ...obj]
@@ -94,11 +95,11 @@ class Parser {
     console.log('\t Usage: ', this.usage, '\n')
     console.log('\t Options: \n')
     this.objs.forEach((obj) => {
-      if (obj.type === OPTION) this.showOption(obj)
+      if (obj.type === OPTION && !obj.dontShow) this.showOption(obj)
     })
     console.log('\n\t Commands: \n')
     this.objs.forEach((obj) => {
-      if (obj.type === COMMAND) this.showCommand(obj)
+      if (obj.type === COMMAND && !obj.dontShow) this.showCommand(obj)
     })
   }
 

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -78,7 +78,6 @@ class Parser {
       }
     }
 
-    console.log('foudn', this.found)
     if (command) command()
     return this.found
   }

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -1,0 +1,82 @@
+import { COMMAND } from './argTypes'
+
+interface Parser {
+  description: string,
+  objs: any[],
+  found: any
+}
+
+class Parser {
+  constructor (description:string, obj:any[]) {
+    this.description = description
+    this.objs = obj
+  }
+
+  add(obj:any[]) {
+    this.objs = [...this.objs, ...obj]
+  }
+
+  getOptions (exicute?:boolean):any {
+    if (this.found) return this.found
+
+    const argv = process.argv
+    if (argv.indexOf('--help') >= 0 || argv.indexOf('-h') >= 0) {
+      this.displayHelp()
+      return {}
+    }
+
+    let argPos = 2
+    this.found = {}
+    let command = null
+    while (argPos < argv.length) {
+      for (let i = 0; i < this.objs.length; i++) {
+        console.log('found: ', this.found)
+        console.log('working on', this.objs[i].name)
+        console.log('for arg', argv[argPos])
+        if (argPos >= argv.length) {
+          console.log("ending on", argv[argPos], argPos)
+          if (command) command()
+          return this.found
+        }
+        if (this.equalsName(argv[argPos], this.objs[i], this.objs[i].type === COMMAND)) {
+          if (this.objs[i].type === COMMAND) {
+            if (exicute && this.objs[i].action) command = this.objs[i].action
+          } else {
+            argPos++
+            this.found[this.objs[i].name] = argv[argPos]
+          }
+          argPos++
+        }
+      }
+    }
+
+    //we should never get here, but better safe than sorry
+    if (command) command()
+    return this.found
+  }
+
+  private equalsName(name:string, obj:any, isCommand:boolean) {
+    if (isCommand && name === obj.name) return true
+    if (name === '--' + obj.name) return true
+    if (name === '-' + obj.name.charAt(0)) return true
+    return false
+  }
+
+  private displayHelp () {
+    console.log('help')
+  }
+}
+
+export default Parser
+
+
+// if (this.objs[i].accepts === 1) {
+//   found[this.objs[i].name] = argv[argPos]
+// } else {
+//   found[this.objs[i].name] = []
+//   while (argPos < argv.length && argv[argPos].charAt(0) !== '-') {
+//     found[this.objs[i].name].push(argv[argPos])
+//     argPos++
+//   }
+//   argPos--
+// }

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -41,9 +41,11 @@ class Parser {
         }
       }
       if (option) {
-        if (option.type !== COMMAND || option.takesArguments) {
+        if (option.type !== COMMAND ||
+          (option.takesArguments && argv[argPos+1].charAt(0) !== '-') // This is for commands like set that *might* take a value, but might also use another option to get that value
+        ) {
           argPos++
-          this.found[option.name] = argv[argPos]
+          this.found[option.mapTo || option.name] = argv[argPos]
         }
         if (exicute && option.action) command = option.action
         argPos++

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -1,4 +1,4 @@
-import { COMMAND } from './argTypes'
+import { COMMAND, OPTION } from './argTypes'
 
 interface Parser {
   description: string,
@@ -82,7 +82,26 @@ class Parser {
   }
 
   private displayHelp () {
-    console.log('help') //TODO: fill me in
+    console.log(this.description, '\n')
+    console.log('\t Usage: ', this.usage, '\n')
+    console.log('\t Options: \n')
+    this.objs.forEach((obj) => {
+      if (obj.type === OPTION) this.showOption(obj)
+    })
+    console.log('\n\t Commands: \n')
+    this.objs.forEach((obj) => {
+      if (obj.type === COMMAND) this.showCommand(obj)
+    })
+  }
+
+  private showOption(obj:any) {
+    console.log(`\t - ${obj.name} (${'--' + obj.name}, ${'-' + obj.name.charAt(0)}): ${obj.description || ''}`)
+    if (obj.useage) console.log(`\t \t Usage: ${obj.useage}`)
+  }
+
+  private showCommand(obj:any) {
+    console.log(`\t - ${obj.name}: ${obj.description || ''}`)
+    if (obj.useage) console.log(`\t \t Usage: ${obj.useage}`)
   }
 }
 

--- a/src/cmd/parser.ts
+++ b/src/cmd/parser.ts
@@ -12,6 +12,20 @@ class Parser {
     this.objs = obj
   }
 
+  /*
+  * add takes an array of options. Options are objects in this format:
+  * @param name [required] this is the name that can the user can type to get
+                           this option or command. for commands the user can use
+                           the name and for options the user can use either
+                           --the-name or -the first letter of the name eg. name:
+                           from-file will be triggered by: -f || --from-file
+  * @param type [required] the type of option. this can be either COMMAND or OPTION
+  * @param action [required (for commands)] the function to be run when a
+                                            command is given by the user.
+  * @param mapTo [optional] the name of the object returned from getOptions
+  * @param description [optional] description of the command or option
+  * @param usage [optional] the useage of a particular command or option
+  */
   add(obj:any[]) {
     this.objs = [...this.objs, ...obj]
   }
@@ -67,7 +81,7 @@ class Parser {
   }
 
   private displayHelp () {
-    console.log('help')
+    console.log('help') //TODO: fill me in
   }
 }
 

--- a/src/cmd/releases.ts
+++ b/src/cmd/releases.ts
@@ -1,28 +1,31 @@
-// import { root, getAppName } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-//
-// export interface ReleasesOptions { }
-// export interface ReleasesArgs { }
-//
-// root
-//   .subCommand<ReleasesOptions, ReleasesArgs>("releases")
-//   .description("Manage Fly apps.")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const appName = getAppName()
-//       const res = await API.get(`/api/v1/apps/${appName}/releases`)
-//       processResponse(res, (res: any) => {
-//         if (res.data.data.length == 0)
-//           return console.log(`No releases for ${appName} yet.`)
-//         for (let r of res.data.data) {
-//           console.log(`v${r.attributes.version} ${r.attributes.reason} by ${r.attributes.author} on ${r.attributes.created_at}`)
-//         }
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
+import { root, getAppName } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+export interface ReleasesOptions { }
+export interface ReleasesArgs { }
+
+root.add([{
+  type: COMMAND,
+  name: 'releases',
+  description: "Manage Fly apps.",
+  action: async () => {
+    try {
+      const appName = getAppName()
+      const res = await API.get(`/api/v1/apps/${appName}/releases`)
+      processResponse(res, (res: any) => {
+        if (res.data.data.length == 0)
+          return console.log(`No releases for ${appName} yet.`)
+        for (let r of res.data.data) {
+          console.log(`v${r.attributes.version} ${r.attributes.reason} by ${r.attributes.author} on ${r.attributes.created_at}`)
+        }
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+}])

--- a/src/cmd/releases.ts
+++ b/src/cmd/releases.ts
@@ -1,28 +1,28 @@
-import { root, getAppName } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-
-export interface ReleasesOptions { }
-export interface ReleasesArgs { }
-
-root
-  .subCommand<ReleasesOptions, ReleasesArgs>("releases")
-  .description("Manage Fly apps.")
-  .action(async (opts, args, rest) => {
-    try {
-      const appName = getAppName()
-      const res = await API.get(`/api/v1/apps/${appName}/releases`)
-      processResponse(res, (res: any) => {
-        if (res.data.data.length == 0)
-          return console.log(`No releases for ${appName} yet.`)
-        for (let r of res.data.data) {
-          console.log(`v${r.attributes.version} ${r.attributes.reason} by ${r.attributes.author} on ${r.attributes.created_at}`)
-        }
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
+// import { root, getAppName } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+//
+// export interface ReleasesOptions { }
+// export interface ReleasesArgs { }
+//
+// root
+//   .subCommand<ReleasesOptions, ReleasesArgs>("releases")
+//   .description("Manage Fly apps.")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const appName = getAppName()
+//       const res = await API.get(`/api/v1/apps/${appName}/releases`)
+//       processResponse(res, (res: any) => {
+//         if (res.data.data.length == 0)
+//           return console.log(`No releases for ${appName} yet.`)
+//         for (let r of res.data.data) {
+//           console.log(`v${r.attributes.version} ${r.attributes.reason} by ${r.attributes.author} on ${r.attributes.created_at}`)
+//         }
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -24,16 +24,19 @@ export const root = new Parser("Fly CLI", "fly [command] [options]", [
   {
     type: OPTION,
     name: 'app',
+    showParams: '<id>',
     description: "App to use for commands."
   },
   {
     type: OPTION,
     name: 'env',
+    showParams: '<env>',
     description: "Environment to use for commands."
   },
   {
     type: OPTION,
     name: 'token',
+    showParams: '<token>',
     description: "Fly Access Token (can be set via environment FLY_ACCESS_TOKEN)"
   }
 ])

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -14,7 +14,7 @@ export interface CommonOptions {
   token: string[]
 }
 
-export const root = new Parser("Fly CLI", [
+export const root = new Parser("Fly CLI", "fly [command] [options]", [
   {
     type: COMMAND,
     name: 'version',
@@ -24,19 +24,16 @@ export const root = new Parser("Fly CLI", [
   {
     type: OPTION,
     name: 'app',
-    accepts: 1, //number of arguments this accepts (in this case just 1 <id>)
     description: "App to use for commands."
   },
   {
     type: OPTION,
     name: 'env',
-    accepts: 1,
     description: "Environment to use for commands."
   },
   {
     type: OPTION,
     name: 'token',
-    accepts: 1,
     description: "Fly Access Token (can be set via environment FLY_ACCESS_TOKEN)"
   }
 ])

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -18,6 +18,7 @@ export const root = new Parser("Fly CLI", [
   {
     type: COMMAND,
     name: 'version',
+    description: 'The current version of Fly CLI',
     action: () => console.log(version)
   },
   {

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -1,4 +1,5 @@
-import { create, Command } from "commandpost";
+import Parser from "./parser";
+import { COMMAND, OPTION } from './argTypes'
 import { getLocalRelease } from '../utils/local'
 
 import YAML = require('js-yaml')
@@ -13,17 +14,35 @@ export interface CommonOptions {
   token: string[]
 }
 
-export const root =
-  create<CommonOptions, any>("fly")
-    .version(version, "-v, --version")
-    .description("Fly CLI")
-    .option("-a, --app <id>", "App to use for commands.")
-    .option("-e, --env <env>", "Environment to use for commands.")
-    .option("--token <token>", "Fly Access Token (can be set via environment FLY_ACCESS_TOKEN)")
-
+export const root = new Parser("Fly CLI", [
+  {
+    type: COMMAND,
+    name: 'version',
+    action: () => console.log(version)
+  },
+  {
+    type: OPTION,
+    name: 'app',
+    accepts: 1, //number of arguments this accepts (in this case just 1 <id>)
+    description: "App to use for commands."
+  },
+  {
+    type: OPTION,
+    name: 'env',
+    accepts: 1,
+    description: "Environment to use for commands."
+  },
+  {
+    type: OPTION,
+    name: 'token',
+    accepts: 1,
+    description: "Fly Access Token (can be set via environment FLY_ACCESS_TOKEN)"
+  }
+])
 
 export function getToken() {
-  let token = root.parsedOpts.token && root.parsedOpts.token[0] || process.env.FLY_ACCESS_TOKEN
+  let opts = root.getOptions(false)
+  let token = opts.token || process.env.FLY_ACCESS_TOKEN
   if (!token) {
     try {
       const creds = getCredentials()
@@ -43,10 +62,11 @@ export function getToken() {
 export const fullAppMatch = /([a-z0-9_.-]+)/i
 
 export function getAppName(env?: string) {
+  let opts = root.getOptions(false)
   const cwd = process.cwd()
-  env = process.env.FLY_ENV || env || root.parsedOpts.env && root.parsedOpts.env[0] || "production"
+  env = process.env.FLY_ENV || env || opts.env || "production"
   const release = getLocalRelease(cwd, env, { noWatch: true })
-  const appName = root.parsedOpts.app && root.parsedOpts.app[0] || release.app
+  const appName = opts.app || release.app
 
   if (!appName) {
     throw new Error("--app option or app (in your .fly.yml) needs to be set.")

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -1,51 +1,62 @@
-// import fs = require('fs')
-// import { root, getAppName } from './root'
-// import { API } from './api'
-// import { processResponse } from '../utils/cli'
-//
-// export interface SecretSetOptions {
-//   filename?: string[]
-// }
-// export interface SecretSetArgs {
-//   key: string,
-//   value?: string
-// }
-//
-// const secrets = root
-//   .subCommand<any, any>("secrets")
-//   .description("Manage your Fly app secrets.")
-//
-// secrets
-//   .subCommand<SecretSetOptions, SecretSetArgs>("set <key> [value]")
-//   .description("Set a secret to use in your config.")
-//   .option("--from-file <filename>", "Use a file's contents as the secret value.")
-//   .usage("fly secrets set <key> [value]")
-//   .action(async (opts, args, rest) => {
-//     try {
-//       const appName = getAppName()
-//
-//       const value = opts.filename ?
-//         fs.readFileSync(opts.filename[0]).toString() :
-//         args.value && args.value
-//
-//       if (!value)
-//         throw new Error("Either a value or --from-file needs to be provided.")
-//
-//       const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
-//         data: {
-//           attributes: {
-//             key: args.key,
-//             value: Buffer.from(value).toString('base64')
-//           }
-//         }
-//       })
-//       processResponse(res, (res: any) => {
-//         console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
-//       })
-//     } catch (e) {
-//       if (e.response)
-//         console.log(e.response.data)
-//       else
-//         throw e
-//     }
-//   })
+import fs = require('fs')
+import { root, getAppName } from './root'
+import { API } from './api'
+import { processResponse } from '../utils/cli'
+import { COMMAND, OPTION } from './argTypes'
+
+export interface SecretSetOptions {
+  filename?: string[]
+}
+export interface SecretSetArgs {
+  key: string,
+  value?: string
+}
+
+root.add([{
+  type: COMMAND,
+  name: "secrets",
+  description: "Manage your Fly app secrets.",
+  action: () => null
+},
+{
+  type: COMMAND,
+  name: 'set',
+  description: "Set a secret to use in your config.",
+  usage: "fly secrets set <key> [value]",
+  takesArguments: true,
+  action: async () => {
+    try {
+      const appName = getAppName()
+      const opts = root.getOptions(false)
+      const value = opts.filename ?
+        fs.readFileSync(opts.filename[0]).toString() :
+        opts.set
+
+      if (!value)
+        throw new Error("Either a value or --from-file needs to be provided.")
+
+      const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
+        data: {
+          attributes: {
+            key: opts.key,
+            value: Buffer.from(value).toString('base64')
+          }
+        }
+      })
+      processResponse(res, (res: any) => {
+        console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
+      })
+    } catch (e) {
+      if (e.response)
+        console.log(e.response.data)
+      else
+        throw e
+    }
+  }
+},
+{
+  type: OPTION,
+  name: 'from-file',
+  mapTo: 'filename',
+  description: "Use a file's contents as the secret value.",
+}])

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -31,7 +31,7 @@ root.add([{
       const opts = root.getOptions(false)
       const value = opts.filename ?
         fs.readFileSync(opts.filename).toString() :
-        opts.set
+        opts.key
 
       if (!value)
         throw new Error("Either a value or --from-file needs to be provided.")

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -60,7 +60,7 @@ root.add([{
   type: OPTION,
   name: 'from-file',
   dontShow: true,
-  respondsTo: 'set',
+  respondsTo: ['set', 'secrets'],
   mapTo: 'filename',
   description: "Use a file's contents as the secret value.",
 }])

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -15,13 +15,13 @@ export interface SecretSetArgs {
 root.add([{
   type: COMMAND,
   name: "secrets",
-  description: "Manage your Fly app secrets.",
-  action: () => null
+  description: "Manage your Fly app secrets."
 },
 {
   type: COMMAND,
   name: 'set',
   dontShow: true,
+  respondsTo: 'secrets',
   description: "Set a secret to use in your config.",
   usage: "fly secrets set <key> [value]",
   takesArguments: true,
@@ -60,6 +60,7 @@ root.add([{
   type: OPTION,
   name: 'from-file',
   dontShow: true,
+  respondsTo: 'set',
   mapTo: 'filename',
   description: "Use a file's contents as the secret value.",
 }])

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -59,6 +59,7 @@ root.add([{
 {
   type: OPTION,
   name: 'from-file',
+  dontShow: true,
   mapTo: 'filename',
   description: "Use a file's contents as the secret value.",
 }])

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -21,6 +21,7 @@ root.add([{
 {
   type: COMMAND,
   name: 'set',
+  dontShow: true,
   description: "Set a secret to use in your config.",
   usage: "fly secrets set <key> [value]",
   takesArguments: true,

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -24,12 +24,13 @@ root.add([{
   description: "Set a secret to use in your config.",
   usage: "fly secrets set <key> [value]",
   takesArguments: true,
+  mapTo: 'key',
   action: async () => {
     try {
       const appName = getAppName()
       const opts = root.getOptions(false)
       const value = opts.filename ?
-        fs.readFileSync(opts.filename[0]).toString() :
+        fs.readFileSync(opts.filename).toString() :
         opts.set
 
       if (!value)

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -1,51 +1,51 @@
-import fs = require('fs')
-import { root, getAppName } from './root'
-import { API } from './api'
-import { processResponse } from '../utils/cli'
-
-export interface SecretSetOptions {
-  filename?: string[]
-}
-export interface SecretSetArgs {
-  key: string,
-  value?: string
-}
-
-const secrets = root
-  .subCommand<any, any>("secrets")
-  .description("Manage your Fly app secrets.")
-
-secrets
-  .subCommand<SecretSetOptions, SecretSetArgs>("set <key> [value]")
-  .description("Set a secret to use in your config.")
-  .option("--from-file <filename>", "Use a file's contents as the secret value.")
-  .usage("fly secrets set <key> [value]")
-  .action(async (opts, args, rest) => {
-    try {
-      const appName = getAppName()
-
-      const value = opts.filename ?
-        fs.readFileSync(opts.filename[0]).toString() :
-        args.value && args.value
-
-      if (!value)
-        throw new Error("Either a value or --from-file needs to be provided.")
-
-      const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
-        data: {
-          attributes: {
-            key: args.key,
-            value: Buffer.from(value).toString('base64')
-          }
-        }
-      })
-      processResponse(res, (res: any) => {
-        console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
+// import fs = require('fs')
+// import { root, getAppName } from './root'
+// import { API } from './api'
+// import { processResponse } from '../utils/cli'
+//
+// export interface SecretSetOptions {
+//   filename?: string[]
+// }
+// export interface SecretSetArgs {
+//   key: string,
+//   value?: string
+// }
+//
+// const secrets = root
+//   .subCommand<any, any>("secrets")
+//   .description("Manage your Fly app secrets.")
+//
+// secrets
+//   .subCommand<SecretSetOptions, SecretSetArgs>("set <key> [value]")
+//   .description("Set a secret to use in your config.")
+//   .option("--from-file <filename>", "Use a file's contents as the secret value.")
+//   .usage("fly secrets set <key> [value]")
+//   .action(async (opts, args, rest) => {
+//     try {
+//       const appName = getAppName()
+//
+//       const value = opts.filename ?
+//         fs.readFileSync(opts.filename[0]).toString() :
+//         args.value && args.value
+//
+//       if (!value)
+//         throw new Error("Either a value or --from-file needs to be provided.")
+//
+//       const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
+//         data: {
+//           attributes: {
+//             key: args.key,
+//             value: Buffer.from(value).toString('base64')
+//           }
+//         }
+//       })
+//       processResponse(res, (res: any) => {
+//         console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
+//       })
+//     } catch (e) {
+//       if (e.response)
+//         console.log(e.response.data)
+//       else
+//         throw e
+//     }
+//   })

--- a/src/cmd/server.ts
+++ b/src/cmd/server.ts
@@ -25,18 +25,21 @@ root.add([
   {
     type: OPTION,
     name: 'port',
+    dontShow: true,
     description: "Port to bind to"
   },
   {
     type: OPTION,
     name: 'uglify',
     bool: true,
+    dontShow: true,
     description: "uglify your code like we'll use in production (warning: slow!)"
   },
   {
     type: OPTION,
     name: 'inspect',
     bool: true,
+    dontShow: true,
     description: "use the v8 inspector on your fly app"
   },
   {

--- a/src/cmd/server.ts
+++ b/src/cmd/server.ts
@@ -25,19 +25,18 @@ root.add([
   {
     type: OPTION,
     name: 'port',
-    accepts: 1,
     description: "Port to bind to"
   },
   {
     type: OPTION,
     name: 'uglify',
-    accepts: 1,
+    bool: true,
     description: "uglify your code like we'll use in production (warning: slow!)"
   },
   {
     type: OPTION,
     name: 'inspect',
-    accepts: 1,
+    bool: true,
     description: "use the v8 inspector on your fly app"
   },
   {

--- a/src/cmd/server.ts
+++ b/src/cmd/server.ts
@@ -46,7 +46,6 @@ root.add([
     description: "Run the local Fly development server",
     action: () => {
       const opts = root.getOptions(false)
-      console.log('opts', opts)
       const { FileAppStore } = require('../file_app_store')
       const { Server } = require('../server')
       const { DefaultContextStore } = require('../default_context_store');

--- a/src/cmd/server.ts
+++ b/src/cmd/server.ts
@@ -26,6 +26,7 @@ root.add([
     type: OPTION,
     name: 'port',
     dontShow: true,
+    respondsTo: 'server',
     description: "Port to bind to"
   },
   {
@@ -33,6 +34,7 @@ root.add([
     name: 'uglify',
     bool: true,
     dontShow: true,
+    respondsTo: 'server',
     description: "uglify your code like we'll use in production (warning: slow!)"
   },
   {
@@ -40,6 +42,7 @@ root.add([
     name: 'inspect',
     bool: true,
     dontShow: true,
+    respondsTo: 'server',
     description: "use the v8 inspector on your fly app"
   },
   {

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -28,6 +28,7 @@ interface TestArgs {
 root.add([{
   type: OPTION,
   name: 'path',
+  dontShow: true,
   description: "Test from a specific path, defaults to {test,spec}/**/*.{test,spec}.js",
 }, {
   type: COMMAND,

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -7,7 +7,7 @@ import { root } from './root'
 
 import log from '../log'
 import { Bridge } from '../bridge/bridge'
-import { COMMAND } from './argTypes'
+import { COMMAND, OPTION } from './argTypes'
 
 const scripts = [
   require.resolve("mocha/mocha"),
@@ -26,8 +26,11 @@ interface TestArgs {
 }
 
 root.add([{
+  type: OPTION,
+  name: 'path',
+  description: "Test from a specific path, defaults to {test,spec}/**/*.{test,spec}.js",
+}, {
   type: COMMAND,
-  takesArguments: true,
   name: 'test',
   description: "Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js",
   action: () => {

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -1,109 +1,109 @@
-import * as fs from 'fs'
-import * as path from 'path'
-import * as winston from 'winston'
-
-import glob = require('glob')
-import { root } from './root'
-
-import log from '../log'
-import { Bridge } from '../bridge/bridge'
-
-const scripts = [
-  require.resolve("mocha/mocha"),
-  require.resolve('../../v8env/testing/setup'),
-].map((filename) => {
-  return {
-    filename: filename,
-    code: fs.readFileSync(filename).toString()
-  }
-})
-
-const runPath = require.resolve("../../v8env/testing/run")
-
-interface TestArgs {
-  paths?: string[]
-}
-
-root
-  .subCommand<any, TestArgs>("test [paths...]")
-  .description("Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js")
-  .action((opts, args, rest) => {
-    const { ivm } = require('../')
-    const { v8Env } = require('../v8env')
-    const { FileAppStore } = require('../file_app_store')
-    const { getWebpackConfig, buildAppWithConfig } = require('../utils/build')
-    const { createContext } = require('../context')
-
-    const cwd = process.cwd()
-
-    let paths = args.paths && args.paths.length ?
-      [].concat.apply([],
-        args.paths.map((f) =>
-          glob.sync(f).map((gf) =>
-            path.resolve(cwd, gf)
-          )
-        )
-      ) :
-      glob.sync('./test/**/*.+(spec|test).js');
-
-    if (paths.length === 0) {
-      console.log("No test files found")
-      return
-    }
-
-    let conf = getWebpackConfig(cwd)
-    conf.entry = paths
-
-    const appStore = new FileAppStore(cwd, { noWatch: true, noSource: true, env: "test" })
-
-    buildAppWithConfig(cwd, conf, { watch: false }, async (err: Error, code: string, hash: string, sourceMap: string) => {
-      if (err)
-        throw err
-
-      try {
-        // await v8Env.waitForReadiness()
-        const iso = new ivm.Isolate({ snapshot: v8Env.snapshot })
-        const ctx = await createContext(iso, new Bridge())
-
-        await ctx.set('_log', new ivm.Reference(function (lvl: string, msg: string, ...args: any[]) {
-          log.log(lvl, msg, ...args)
-        }))
-
-        const app = appStore.app
-
-        ctx.meta.app = app
-
-        ctx.logger.add(winston.transports.Console, {
-          formatter: function (options: any) {
-            return options.message
-          }
-        })
-
-        await ctx.set('_mocha_done', new ivm.Reference(function (failures: number) {
-          if (failures)
-            return process.exit(1)
-          process.exit()
-        }))
-
-        for (let script of scripts) {
-          const compiled = await iso.compileScript(script.code, script)
-          await compiled.run(ctx.ctx)
-        }
-
-        await ctx.set('app', app.forV8())
-
-        const bundleName = `bundle-${hash}`
-        const sourceFilename = `${bundleName}.js`
-        const sourceMapFilename = `${bundleName}.map.json`
-        const bundleScript = await iso.compileScript(code, { filename: sourceFilename })
-        await bundleScript.run(ctx.ctx)
-
-        const runScript = await iso.compileScript(fs.readFileSync(runPath).toString(), { filename: runPath })
-        console.log("Running tests...")
-        await runScript.run(ctx.ctx)
-      } catch (err) {
-        console.error(err.stack)
-      }
-    })
-  })
-
+// import * as fs from 'fs'
+// import * as path from 'path'
+// import * as winston from 'winston'
+//
+// import glob = require('glob')
+// import { root } from './root'
+//
+// import log from '../log'
+// import { Bridge } from '../bridge/bridge'
+//
+// const scripts = [
+//   require.resolve("mocha/mocha"),
+//   require.resolve('../../v8env/testing/setup'),
+// ].map((filename) => {
+//   return {
+//     filename: filename,
+//     code: fs.readFileSync(filename).toString()
+//   }
+// })
+//
+// const runPath = require.resolve("../../v8env/testing/run")
+//
+// interface TestArgs {
+//   paths?: string[]
+// }
+//
+// root
+//   .subCommand<any, TestArgs>("test [paths...]")
+//   .description("Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js")
+//   .action((opts, args, rest) => {
+//     const { ivm } = require('../')
+//     const { v8Env } = require('../v8env')
+//     const { FileAppStore } = require('../file_app_store')
+//     const { getWebpackConfig, buildAppWithConfig } = require('../utils/build')
+//     const { createContext } = require('../context')
+//
+//     const cwd = process.cwd()
+//
+//     let paths = args.paths && args.paths.length ?
+//       [].concat.apply([],
+//         args.paths.map((f) =>
+//           glob.sync(f).map((gf) =>
+//             path.resolve(cwd, gf)
+//           )
+//         )
+//       ) :
+//       glob.sync('./test/**/*.+(spec|test).js');
+//
+//     if (paths.length === 0) {
+//       console.log("No test files found")
+//       return
+//     }
+//
+//     let conf = getWebpackConfig(cwd)
+//     conf.entry = paths
+//
+//     const appStore = new FileAppStore(cwd, { noWatch: true, noSource: true, env: "test" })
+//
+//     buildAppWithConfig(cwd, conf, { watch: false }, async (err: Error, code: string, hash: string, sourceMap: string) => {
+//       if (err)
+//         throw err
+//
+//       try {
+//         // await v8Env.waitForReadiness()
+//         const iso = new ivm.Isolate({ snapshot: v8Env.snapshot })
+//         const ctx = await createContext(iso, new Bridge())
+//
+//         await ctx.set('_log', new ivm.Reference(function (lvl: string, msg: string, ...args: any[]) {
+//           log.log(lvl, msg, ...args)
+//         }))
+//
+//         const app = appStore.app
+//
+//         ctx.meta.app = app
+//
+//         ctx.logger.add(winston.transports.Console, {
+//           formatter: function (options: any) {
+//             return options.message
+//           }
+//         })
+//
+//         await ctx.set('_mocha_done', new ivm.Reference(function (failures: number) {
+//           if (failures)
+//             return process.exit(1)
+//           process.exit()
+//         }))
+//
+//         for (let script of scripts) {
+//           const compiled = await iso.compileScript(script.code, script)
+//           await compiled.run(ctx.ctx)
+//         }
+//
+//         await ctx.set('app', app.forV8())
+//
+//         const bundleName = `bundle-${hash}`
+//         const sourceFilename = `${bundleName}.js`
+//         const sourceMapFilename = `${bundleName}.map.json`
+//         const bundleScript = await iso.compileScript(code, { filename: sourceFilename })
+//         await bundleScript.run(ctx.ctx)
+//
+//         const runScript = await iso.compileScript(fs.readFileSync(runPath).toString(), { filename: runPath })
+//         console.log("Running tests...")
+//         await runScript.run(ctx.ctx)
+//       } catch (err) {
+//         console.error(err.stack)
+//       }
+//     })
+//   })
+//

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -1,109 +1,113 @@
-// import * as fs from 'fs'
-// import * as path from 'path'
-// import * as winston from 'winston'
-//
-// import glob = require('glob')
-// import { root } from './root'
-//
-// import log from '../log'
-// import { Bridge } from '../bridge/bridge'
-//
-// const scripts = [
-//   require.resolve("mocha/mocha"),
-//   require.resolve('../../v8env/testing/setup'),
-// ].map((filename) => {
-//   return {
-//     filename: filename,
-//     code: fs.readFileSync(filename).toString()
-//   }
-// })
-//
-// const runPath = require.resolve("../../v8env/testing/run")
-//
-// interface TestArgs {
-//   paths?: string[]
-// }
-//
-// root
-//   .subCommand<any, TestArgs>("test [paths...]")
-//   .description("Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js")
-//   .action((opts, args, rest) => {
-//     const { ivm } = require('../')
-//     const { v8Env } = require('../v8env')
-//     const { FileAppStore } = require('../file_app_store')
-//     const { getWebpackConfig, buildAppWithConfig } = require('../utils/build')
-//     const { createContext } = require('../context')
-//
-//     const cwd = process.cwd()
-//
-//     let paths = args.paths && args.paths.length ?
-//       [].concat.apply([],
-//         args.paths.map((f) =>
-//           glob.sync(f).map((gf) =>
-//             path.resolve(cwd, gf)
-//           )
-//         )
-//       ) :
-//       glob.sync('./test/**/*.+(spec|test).js');
-//
-//     if (paths.length === 0) {
-//       console.log("No test files found")
-//       return
-//     }
-//
-//     let conf = getWebpackConfig(cwd)
-//     conf.entry = paths
-//
-//     const appStore = new FileAppStore(cwd, { noWatch: true, noSource: true, env: "test" })
-//
-//     buildAppWithConfig(cwd, conf, { watch: false }, async (err: Error, code: string, hash: string, sourceMap: string) => {
-//       if (err)
-//         throw err
-//
-//       try {
-//         // await v8Env.waitForReadiness()
-//         const iso = new ivm.Isolate({ snapshot: v8Env.snapshot })
-//         const ctx = await createContext(iso, new Bridge())
-//
-//         await ctx.set('_log', new ivm.Reference(function (lvl: string, msg: string, ...args: any[]) {
-//           log.log(lvl, msg, ...args)
-//         }))
-//
-//         const app = appStore.app
-//
-//         ctx.meta.app = app
-//
-//         ctx.logger.add(winston.transports.Console, {
-//           formatter: function (options: any) {
-//             return options.message
-//           }
-//         })
-//
-//         await ctx.set('_mocha_done', new ivm.Reference(function (failures: number) {
-//           if (failures)
-//             return process.exit(1)
-//           process.exit()
-//         }))
-//
-//         for (let script of scripts) {
-//           const compiled = await iso.compileScript(script.code, script)
-//           await compiled.run(ctx.ctx)
-//         }
-//
-//         await ctx.set('app', app.forV8())
-//
-//         const bundleName = `bundle-${hash}`
-//         const sourceFilename = `${bundleName}.js`
-//         const sourceMapFilename = `${bundleName}.map.json`
-//         const bundleScript = await iso.compileScript(code, { filename: sourceFilename })
-//         await bundleScript.run(ctx.ctx)
-//
-//         const runScript = await iso.compileScript(fs.readFileSync(runPath).toString(), { filename: runPath })
-//         console.log("Running tests...")
-//         await runScript.run(ctx.ctx)
-//       } catch (err) {
-//         console.error(err.stack)
-//       }
-//     })
-//   })
-//
+import * as fs from 'fs'
+import * as path from 'path'
+import * as winston from 'winston'
+
+import glob = require('glob')
+import { root } from './root'
+
+import log from '../log'
+import { Bridge } from '../bridge/bridge'
+import { COMMAND } from './argTypes'
+
+const scripts = [
+  require.resolve("mocha/mocha"),
+  require.resolve('../../v8env/testing/setup'),
+].map((filename) => {
+  return {
+    filename: filename,
+    code: fs.readFileSync(filename).toString()
+  }
+})
+
+const runPath = require.resolve("../../v8env/testing/run")
+
+interface TestArgs {
+  paths?: string[]
+}
+
+root.add([{
+  type: COMMAND,
+  takesArguments: true,
+  name: 'test',
+  description: "Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js",
+  action: () => {
+    const opts = root.getOptions(false)
+    const { ivm } = require('../')
+    const { v8Env } = require('../v8env')
+    const { FileAppStore } = require('../file_app_store')
+    const { getWebpackConfig, buildAppWithConfig } = require('../utils/build')
+    const { createContext } = require('../context')
+
+    const cwd = process.cwd()
+
+    let paths = opts.paths && opts.paths.length ?
+      [].concat.apply([],
+        opts.paths.map((f:any) =>
+          glob.sync(f).map((gf) =>
+            path.resolve(cwd, gf)
+          )
+        )
+      ) :
+      glob.sync('./test/**/*.+(spec|test).js');
+
+    if (paths.length === 0) {
+      console.log("No test files found")
+      return
+    }
+
+    let conf = getWebpackConfig(cwd)
+    conf.entry = paths
+
+    const appStore = new FileAppStore(cwd, { noWatch: true, noSource: true, env: "test" })
+
+    buildAppWithConfig(cwd, conf, { watch: false }, async (err: Error, code: string, hash: string, sourceMap: string) => {
+      if (err)
+        throw err
+
+      try {
+        // await v8Env.waitForReadiness()
+        const iso = new ivm.Isolate({ snapshot: v8Env.snapshot })
+        const ctx = await createContext(iso, new Bridge())
+
+        await ctx.set('_log', new ivm.Reference(function (lvl: string, msg: string, ...args: any[]) {
+          log.log(lvl, msg, ...args)
+        }))
+
+        const app = appStore.app
+
+        ctx.meta.app = app
+
+        ctx.logger.add(winston.transports.Console, {
+          formatter: function (options: any) {
+            return options.message
+          }
+        })
+
+        await ctx.set('_mocha_done', new ivm.Reference(function (failures: number) {
+          if (failures)
+            return process.exit(1)
+          process.exit()
+        }))
+
+        for (let script of scripts) {
+          const compiled = await iso.compileScript(script.code, script)
+          await compiled.run(ctx.ctx)
+        }
+
+        await ctx.set('app', app.forV8())
+
+        const bundleName = `bundle-${hash}`
+        const sourceFilename = `${bundleName}.js`
+        const sourceMapFilename = `${bundleName}.map.json`
+        const bundleScript = await iso.compileScript(code, { filename: sourceFilename })
+        await bundleScript.run(ctx.ctx)
+
+        const runScript = await iso.compileScript(fs.readFileSync(runPath).toString(), { filename: runPath })
+        console.log("Running tests...")
+        await runScript.run(ctx.ctx)
+      } catch (err) {
+        console.error(err.stack)
+      }
+    })
+  }
+}])

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -29,6 +29,7 @@ root.add([{
   type: OPTION,
   name: 'path',
   dontShow: true,
+  respondsTo: 'test',
   description: "Test from a specific path, defaults to {test,spec}/**/*.{test,spec}.js",
 }, {
   type: COMMAND,

--- a/test/command.spec.ts
+++ b/test/command.spec.ts
@@ -1,0 +1,63 @@
+import { expect, assert } from 'chai'
+import { root, getToken } from '../src/cmd/root';
+
+describe('Commman Tests', () => {
+  describe('All apps options and commands work', () => {
+    expect(testWith(['', '', 'apps'])).not.to.throw
+    expect(testWith(['', '', 'apps', 'create', 'foo']).name).to.equal('foo')
+  })
+  describe('All orgs options and commands work', () => {
+    expect(testWith(['', '', 'orgs'])).not.to.throw
+  })
+  describe('All deploy options and commands work', () => {
+    expect(testWith(['', '', 'deploy'])).not.to.throw
+  })
+  describe('All releases options and commands work', () => {
+    expect(testWith(['', '', 'releases'])).not.to.throw
+  })
+  describe('All secrets options and commands work', () => {
+    expect(testWith(['', '', 'secrets'])).not.to.throw
+    expect(testWith(['', '', 'secrets', 'set', 'foo']).key).to.equal('foo')
+    expect(testWith(['', '', 'secrets', '--from-file', 'foo']).filename).to.equal('foo')
+  })
+  describe('All test options and commands work', () => {
+    expect(testWith(['', '', 'test'])).not.to.throw
+    expect(testWith(['', '', 'test', '--path', 'foo']).path).to.equal('foo')
+  })
+  describe('All server options and commands work', () => {
+    expect(testWith(['', '', 'server'])).not.to.throw
+    expect(testWith(['', '', 'server', '--port', 'foo']).port).to.equal('foo')
+    expect(testWith(['', '', 'server', '--uglify']).uglify).to.equal(true)
+    expect(testWith(['', '', 'server', '--inspect']).inspect).to.equal(true)
+  })
+  describe('All hostnames options and commands work', () => {
+    expect(testWith(['', '', 'hostnames'])).not.to.throw
+    expect(testWith(['', '', 'hostnames', 'add', 'foo']).hostname).to.equal('foo')
+  })
+  describe('All login options and commands work', () => {
+    expect(testWith(['', '', 'login'])).not.to.throw
+  })
+  describe('All fetch options and commands work', () => {
+    expect(testWith(['', '', 'fetch'])).not.to.throw
+  })
+  describe('All logs options and commands work', () => {
+    expect(testWith(['', '', 'logs'])).not.to.throw
+  })
+})
+
+function testWith(args:string[]) {
+  require("../src/cmd/apps");
+  require("../src/cmd/orgs");
+  require("../src/cmd/deploy");
+  require("../src/cmd/releases");
+  require("../src/cmd/secrets");
+  require("../src/cmd/test");
+  require("../src/cmd/server");
+  require("../src/cmd/hostnames");
+  require("../src/cmd/login");
+  require("../src/cmd/fetch");
+  require("../src/cmd/logs");
+
+  root.setArgs(args)
+  return root.getOptions(false, true)
+}

--- a/test/command.spec.ts
+++ b/test/command.spec.ts
@@ -5,6 +5,8 @@ describe('Commman Tests', () => {
   describe('All apps options and commands work', () => {
     expect(testWith(['', '', 'apps'])).not.to.throw
     expect(testWith(['', '', 'apps', 'create', 'foo']).name).to.equal('foo')
+
+    expect(() => testWith(['', '', 'server', 'create', 'foo'])).to.throw()
   })
   describe('All orgs options and commands work', () => {
     expect(testWith(['', '', 'orgs'])).not.to.throw
@@ -19,29 +21,40 @@ describe('Commman Tests', () => {
     expect(testWith(['', '', 'secrets'])).not.to.throw
     expect(testWith(['', '', 'secrets', 'set', 'foo']).key).to.equal('foo')
     expect(testWith(['', '', 'secrets', '--from-file', 'foo']).filename).to.equal('foo')
+
+    expect(() => testWith(['', '', 'server', 'set', 'foo'])).to.throw()
+    expect(() => testWith(['', '', 'server', '--from-file', 'foo'])).to.throw()
   })
   describe('All test options and commands work', () => {
     expect(testWith(['', '', 'test'])).not.to.throw
     expect(testWith(['', '', 'test', '--path', 'foo']).path).to.equal('foo')
+
+    expect(() => testWith(['', '', 'server', '--path', 'foo'])).to.throw()
   })
   describe('All server options and commands work', () => {
     expect(testWith(['', '', 'server'])).not.to.throw
     expect(testWith(['', '', 'server', '--port', 'foo']).port).to.equal('foo')
     expect(testWith(['', '', 'server', '--uglify']).uglify).to.equal(true)
     expect(testWith(['', '', 'server', '--inspect']).inspect).to.equal(true)
+
+    expect(() => testWith(['', '', 'secrets', '--port', 'foo'])).to.throw()
+    expect(() => testWith(['', '', 'secrets', '--uglify'])).to.throw()
+    expect(() => testWith(['', '', 'secrets', '--inspect'])).to.throw()
   })
   describe('All hostnames options and commands work', () => {
     expect(testWith(['', '', 'hostnames'])).not.to.throw
     expect(testWith(['', '', 'hostnames', 'add', 'foo']).hostname).to.equal('foo')
+
+    expect(() => testWith(['', '', 'server', 'add', 'foo'])).to.throw()
   })
   describe('All login options and commands work', () => {
-    expect(testWith(['', '', 'login'])).not.to.throw
+    expect(() => testWith(['', '', 'login'])).not.to.throw
   })
   describe('All fetch options and commands work', () => {
-    expect(testWith(['', '', 'fetch'])).not.to.throw
+    expect(() => testWith(['', '', 'fetch'])).not.to.throw
   })
   describe('All logs options and commands work', () => {
-    expect(testWith(['', '', 'logs'])).not.to.throw
+    expect(() => testWith(['', '', 'logs'])).not.to.throw
   })
 })
 


### PR DESCRIPTION
This PR allows us to parse every option we receive. 

### Benefits
 - Allows options and commands to be in any order #58
 - Every option and command is tested
 - Every option and command work
 - Customizable if we need to change anything down the road

### Usage
```
$ fly test --path foo
$ fly --path foo test # this also works
$ fly -p foo test # this also works

# more examples
$ fly --port 1234 server --uglify -i # start server on port 1234 enable both uglify and inspect
$ fly secrets set foo
$ fly secrets set --from-file foo
```
<details>
<summary>Usage</summary>
<br>

```
$ fly
Fly CLI

	 Usage:  fly [command] [options]

	 Options:

	 - app (--app, -a): App to use for commands.
	 - env (--env, -e): Environment to use for commands.
	 - token (--token, -t): Fly Access Token (can be set via environment FLY_ACCESS_TOKEN)
	 - from-file (--from-file, -f): Use a file's contents as the secret value.
	 - path (--path, -p): Test from a specific path, defaults to {test,spec}/**/*.{test,spec}.js
	 - port (--port, -p): Port to bind to
	 - uglify (--uglify, -u): uglify your code like we'll use in production (warning: slow!)
	 - inspect (--inspect, -i): use the v8 inspector on your fly app

	 Commands:

	 - version: The current version of Fly CLI
	 - apps: Manage Fly apps.
	 - create: Create a Fly app.
	 - orgs: Manage Fly orgs.
	 - deploy: Deploy your local Fly app.
	 - releases: Manage Fly apps.
	 - secrets: Manage your Fly app secrets.
	 - set: Set a secret to use in your config.
	 - test: Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js
	 - server: Run the local Fly development server
	 - hostnames: Manage Fly app's hostnames.
	 - add: Add a hostname to your fly app.
	 - login: Login to Fly and save credentials locally.
	 - fetch: Fetch your Fly app locally.
	 - logs: Logs from your app.
```

</details>

### COMMAND/OPTION object structure
[snippet](https://github.com/pudility/fly/blob/flags/src/cmd/parser.ts#L22-L37)
```JavaScript
  /*
  * add takes an array of options. Options are objects in this format:
  * @property name [required] this is the name that can the user can type to get
                           this option or command. for commands the user can use
                           the name and for options the user can use either
                           --the-name or -the first letter of the name eg. name:
                           from-file will be triggered by: -f || --from-file
  * @property type [required] the type of option. this can be either COMMAND or OPTION
  * @property action [required (for commands)] the function to be run when a
                                            command is given by the user.
  * @property mapTo [optional] the name of the object returned from getOptions
  * @property description [optional] description of the command or option
  * @property usage [optional] the useage of a particular command or option
  * @property takesArguments [optional] allows commands to take arguments
  * @property bool [optional] makes the option not take any value
  */
```
### Testing
[Every command and option is tested to make sure that they work properly.](https://github.com/pudility/fly/blob/flags/test/command.spec.ts)