### PR TITLE
Fixes `secret` not working as documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ Using `fly deploy`, here's what happens:
 - We create a "release" for your app, those are immutable, changing anything (by using `fly deploy` or `fly secrets set`) will trigger a new release which will be deployed automatically
 - Your code is distributed instantly(-ish) across our global fleet of servers
 
+## Development
+
+```zsh
+# to install
+npm install // we currently use npm, not yarn
+# to test a particular command (e.g., the cli `apps` sub-command)
+npm run dev -- src/cmd/index.ts apps
+# to watch for file changes and repeat a command
+npm run watch -- src/cmd/index.ts apps
+```
 
 ## Open core
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -571,8 +571,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -9668,6 +9667,130 @@
         "wrappy": "1.0.2"
       }
     },
+    "onchange": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/onchange/-/onchange-3.3.0.tgz",
+      "integrity": "sha512-0ZQIdGkhG8Y+r8BIcjjDV93X59KkZ4Cc+ZxA9N+wA/3vm1cvd8/f2NXlCPCZpowSd78eCERk29dtuS8+X97MLg==",
+      "requires": {
+        "arrify": "1.0.1",
+        "chokidar": "1.7.0",
+        "cross-spawn": "5.1.0",
+        "minimist": "1.2.0",
+        "tree-kill": "1.2.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "requires": {
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
@@ -11799,8 +11922,7 @@
     "tree-kill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
-      "dev": true
+      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg=="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -11920,7 +12042,7 @@
         "fs-extra": "5.0.0",
         "handlebars": "4.0.11",
         "highlight.js": "9.12.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "marked": "0.3.19",
         "minimatch": "3.0.4",
         "progress": "2.0.0",
@@ -11939,9 +12061,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "build:cli:live": "npm run build:cli -- -w",
     "prepublishOnly": "npm run build && npm run doc:v8env",
     "release": "standard-version",
-    "doc:v8env": "./node_modules/typedoc/bin/typedoc --tsconfig ./v8env/ts/tsconfig.json"
+    "doc:v8env": "./node_modules/typedoc/bin/typedoc --tsconfig ./v8env/ts/tsconfig.json",
+    "dev": "./node_modules/.bin/ts-node",
+    "watch": "./node_modules/.bin/onchange 'src/**/*.ts' --initial --poll -- npm run dev"
   },
   "bin": {
     "fly": "lib/cmd/index.js"
@@ -97,6 +99,7 @@
     "isolated-vm": "^1.5.2",
     "js-yaml": "^3.10.0",
     "mocha": "^4.0.1",
+    "onchange": "^3.3.0",
     "promise.prototype.finally": "^3.1.0",
     "promptly": "^3.0.3",
     "segfault-handler": "^1.0.0",

--- a/src/cmd/secrets.ts
+++ b/src/cmd/secrets.ts
@@ -12,45 +12,59 @@ export interface SecretSetArgs {
   value?: string
 }
 
-const secrets = root
+function addSubCommands(instance: Command<CommonOptions, any>) {
+  instance
+    .subCommand<SecretSetOptions, SecretSetArgs>("set <key> [value]")
+    .description("Set a secret to use in your config.")
+    .option("--from-file <filename>", "Use a file's contents as the secret value.")
+    .usage("fly secrets set <key> [value]")
+    .action(async function (this: Command<SecretSetOptions, SecretSetArgs>, opts, args, rest) {
+      const API = apiClient(this)
+      try {
+        const appName = getAppName(this, { env: ['production'] })
+
+        const value = opts.filename ?
+          fs.readFileSync(opts.filename[0]).toString() :
+          args.value && args.value
+
+        if (!value)
+          throw new Error("Either a value or --from-file needs to be provided.")
+
+        const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
+          data: {
+            attributes: {
+              key: args.key,
+              value: Buffer.from(value).toString('base64')
+            }
+          }
+        })
+        processResponse(res, (res: any) => {
+          console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
+        })
+      } catch (e) {
+        if (e.response)
+          console.log(e.response.data)
+        else
+          throw e
+      }
+    })
+
+  return instance
+}
+
+const secrets: Command<CommonOptions, any> = root
   .subCommand<any, any>("secrets")
   .description("Manage your Fly app secrets.")
 
-const secretsSet = secrets
-  .subCommand<SecretSetOptions, SecretSetArgs>("set <key> [value]")
-  .description("Set a secret to use in your config.")
-  .option("--from-file <filename>", "Use a file's contents as the secret value.")
-  .usage("fly secrets set <key> [value]")
-  .action(async function (this: Command<SecretSetOptions, SecretSetArgs>, opts, args, rest) {
-    const API = apiClient(this)
-    try {
-      const appName = getAppName(this, { env: ['production'] })
+/* I think we'd much rather have aliases not be displayed in the Commands list going forward. This will require a hack of the `commandpost` package which I also think I can do, having read their source code. Basically just extend their main class to include an `alias` function (e.g. `.alias('env')`) function that adds another subcommand sans-description, or adds more params to `.subCommand`. We can do that without making changes to their repo I think. */
+const secret: Command<CommonOptions, any> = root
+  .subCommand<any, any>("secret")
+  .description("Alias for 'secrets' command.")
 
-      const value = opts.filename ?
-        fs.readFileSync(opts.filename[0]).toString() :
-        args.value && args.value
-
-      if (!value)
-        throw new Error("Either a value or --from-file needs to be provided.")
-
-      const res = await API.patch(`/api/v1/apps/${appName}/secrets`, {
-        data: {
-          attributes: {
-            key: args.key,
-            value: Buffer.from(value).toString('base64')
-          }
-        }
-      })
-      processResponse(res, (res: any) => {
-        console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
-      })
-    } catch (e) {
-      if (e.response)
-        console.log(e.response.data)
-      else
-        throw e
-    }
-  })
+const secretSet = addSubCommands(secret)
+const secretsSet = addSubCommands(secrets)
 
 addCommonOptions(secrets)
 addCommonOptions(secretsSet)
+addCommonOptions(secret)
+addCommonOptions(secretSet)


### PR DESCRIPTION
This creates bit of an aesthetic issue:

```zsh
Fly CLI

  # snip

  Commands:

    apps       Manage Fly apps.
    orgs       Manage Fly orgs.
    deploy     Deploy your local Fly app.
    releases   Manage Fly apps.
    secrets    Manage your Fly app secrets.
    secret     Alias for 'secrets' command. 
    test       Run unit tests, defaults to {test,spec}/**/*.{test,spec}.js
    server     Run the local Fly development server
    hostnames  Manage Fly app's hostnames.
    login      Login to Fly and save credentials locally.
    fetch      Fetch your Fly app locally.
    logs       Logs from your app.
```

Line 10 shows the alias `secret`, which could get pretty annoying if we also create singular names for apps. I have note about this here: https://github.com/superfly/fly/pull/74/files#diff-9ae1e7740a635186d660ea4b273a0401R59. But We can also just change their matching of sub command names from being `===` for being regex that, or otherwise allows plural and non-plural all-around.

BTW, this PR is being submitted because the docs were wrong on how to use `secrets` and I thought rather than change the docs, maybe allow aliases for some stuff.

<img width="461" alt="screen shot 2018-04-28 at 4 24 31 pm" src="https://user-images.githubusercontent.com/3739277/39404344-5e15cdde-4b46-11e8-8bdc-f8e285c20f9f.png">
