### PR TITLE
Rewrite host for proxied requests

### DIFF
--- a/v8env/ts/fly/proxy.ts
+++ b/v8env/ts/fly/proxy.ts
@@ -70,6 +70,11 @@ export function buildProxyRequest(origin: string | URL, options: ProxyOptions, r
   breq.headers.set("x-forwarded-for", (<any>req).remoteAddr)
   breq.headers.set("x-forwarded-host", url.hostname)
 
+  // modify host header like we do the url if present on the request
+  if (req.headers.has('host')) {
+    breq.headers.set('host', origin.hostname)
+  }
+
   if (options.headers) {
     for (const h of Object.getOwnPropertyNames(options.headers)) {
       const v = options.headers[h]

--- a/v8env_test/proxy.spec.js
+++ b/v8env_test/proxy.spec.js
@@ -3,12 +3,22 @@ import { expect } from 'chai'
 import * as proxy from '@fly/proxy'
 
 const origin = "https://fly.io/proxy/"
-const req = new Request("https://wat.com/path/to/thing", { headers: { "host": "wut.com" } })
+const req = new Request("https://wat.com/path/to/thing", { headers: { "host": "wat.com" } })
+
 describe("proxy", () => {
   it('includes host header and base path properly', () => {
     const breq = proxy.buildProxyRequest(origin, {}, req)
     const url = new URL(breq.url)
+    expect(breq.headers.get("host")).to.eq("fly.io")
+    expect(url.hostname).to.eq("fly.io")
+    expect(url.pathname).to.eq("/proxy/path/to/thing")
+  })
+
+  it('includes explicit host header if different than origin', () => {
+    const breq = proxy.buildProxyRequest(origin, { headers: { "host": "wut.com" } }, req)
+    const url = new URL(breq.url)
     expect(breq.headers.get("host")).to.eq("wut.com")
+    expect(url.hostname).to.eq("fly.io")
     expect(url.pathname).to.eq("/proxy/path/to/thing")
   })
 


### PR DESCRIPTION
A request to `curl -v https://fly.io` will set the `Host` header to `fly.io`.

When a proxy rewrites the URL from `https://endpoint.com` to `https://origin.com` it should also rewrite the `Host` header from `endpoint.com` to `origin.com` if the header is set to begin with.

For sites that use virtual hosts (checking the "Host" header) this will be necessary.