### PR TITLE
Cache errors

### DIFF
--- a/src/bridge/fly/cache.ts
+++ b/src/bridge/fly/cache.ts
@@ -15,7 +15,13 @@ registerBridge('flyCacheSet', function cacheSet(rt: Runtime, bridge: Bridge, key
     return
   }
 
-  const buf = Buffer.from(value)
+  let buf: Buffer
+  try {
+    buf = Buffer.from(value)
+  } catch (err) {
+    callback.applyIgnored(null, [err.toString()])
+    return
+  }
   bridge.cacheStore.set(k, buf, ttl).then((ok) => {
     rt.reportUsage("cache:set", { size: buf.byteLength })
     callback.applyIgnored(null, [null, ok])
@@ -54,6 +60,6 @@ registerBridge('flyCacheGet',
       callback.applyIgnored(null, [null, transferInto(buf)])
     }).catch((err) => {
       log.error("got err in cache.get", err)
-      callback.applyIgnored(null, [err.toString()])
+      callback.applyIgnored(null, [null, null]) // swallow errors on get for now
     })
   })

--- a/src/bridge/fly/cache.ts
+++ b/src/bridge/fly/cache.ts
@@ -7,7 +7,7 @@ import { Runtime } from '../../runtime';
 
 const errCacheStoreUndefined = new Error("cacheStore is not defined in the config.")
 
-registerBridge('flyCacheSet', function cacheSet(rt: Runtime, bridge: Bridge, key: string, value: ArrayBuffer, ttl: number, callback: ivm.Reference<Function>) {
+registerBridge('flyCacheSet', function cacheSet(rt: Runtime, bridge: Bridge, key: string, value: ArrayBuffer | string, ttl: number, callback: ivm.Reference<Function>) {
   let k = "cache:" + rt.app.name + ":" + key
 
   if (!bridge.cacheStore) {
@@ -17,7 +17,12 @@ registerBridge('flyCacheSet', function cacheSet(rt: Runtime, bridge: Bridge, key
 
   let buf: Buffer
   try {
-    buf = Buffer.from(value)
+    if (value instanceof ArrayBuffer) {
+      buf = Buffer.from(value)
+    } else {
+      // handle strings and garbage inputs reasonably
+      buf = Buffer.from(value.toString(), "utf8")
+    }
   } catch (err) {
     callback.applyIgnored(null, [err.toString()])
     return

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -25,5 +25,8 @@ export function transferInto(buffer: Buffer | ArrayBuffer | TypedArray | null): 
 }
 
 function transferArrayBufferInto(buffer: ArrayBuffer | SharedArrayBuffer | TypedArray) {
+  if (buffer.byteLength === 0) {
+    return new ivm.ExternalCopy(buffer).copyInto({ release: true, transferIn: true })
+  }
   return new ivm.ExternalCopy(buffer, { transferOut: true }).copyInto({ release: true, transferIn: true });
 }

--- a/test/fly.cache.spec.ts
+++ b/test/fly.cache.spec.ts
@@ -42,4 +42,12 @@ describe('Cache API', function () {
     expect(res.status).to.equal(200)
     expect(res.data).to.equal(data)
   })
+
+  it('getString with garbage cache data', async () => {
+    let data = new Buffer([-1, -1, -1, -1])
+    await cacheStore.set("cache:test-app-id:http://test/cache-api/get", data)
+
+    let res = await axios.get("http://127.0.0.1:3333/cache-api/get", { headers: { 'Host': 'test' } })
+    expect(res.status).to.equal(200)
+  })
 })

--- a/v8env/ts/fly/cache.ts
+++ b/v8env/ts/fly/cache.ts
@@ -36,7 +36,11 @@ export function get(key: string) {
 export async function getString(key: string) {
   const buf = await get(key)
   if (!buf) { return buf }
-  return new TextDecoder("utf-8").decode(buf)
+  try {
+    return new TextDecoder("utf-8").decode(buf)
+  } catch (err) {
+    return null
+  }
 }
 
 /**
@@ -47,6 +51,9 @@ export async function getString(key: string) {
  * @returns true if the set was successful
  */
 export function set(key: string, value: string | ArrayBuffer, ttl?: number) {
+  if (typeof value !== "string" && !(value instanceof ArrayBuffer)) {
+    throw new Error("Cache values must be either a string or array buffer")
+  }
   return new Promise<boolean>(function cacheSetPromise(resolve, reject) {
     bridge.dispatch("flyCacheSet", key, value, ttl, function cacheSetCallback(err: string | null, ok?: boolean) {
       if (err != null) {

--- a/v8env_test/fly.cache.spec.js
+++ b/v8env_test/fly.cache.spec.js
@@ -33,16 +33,18 @@ describe("@fly/cache", () => {
 
   it("accepts empty arrayBuffer", async () => {
     const k = `cache-test${Math.random()}`
-    const result = await cache.set(k, new ArrayBuffer(0))
-    expect(result).to.eq(true)
-  })
-
-  it("handles failed get calls", async () => {
-    const k = `cache-test${Math.random()}`
 
     await cache.set(k, new ArrayBuffer(0))
 
     const result = await cache.get(k)
-    expect(result).to.eq(null)
+    expect(result).to.be.a('ArrayBuffer')
+    expect(result.byteLength).to.eq(0)
+  })
+
+  it("handles blank strings", async () => {
+    const k = `cache-test${Math.random()}`
+    await cache.set(k, '')
+    const result = await cache.get(k)
+    console.log(result)
   })
 })

--- a/v8env_test/fly.cache.spec.js
+++ b/v8env_test/fly.cache.spec.js
@@ -30,4 +30,19 @@ describe("@fly/cache", () => {
     const newVal = await cache.get("cache-delete-key")
     expect(newVal).to.eq(null)
   })
+
+  it("accepts empty arrayBuffer", async () => {
+    const k = `cache-test${Math.random()}`
+    const result = await cache.set(k, new ArrayBuffer(0))
+    expect(result).to.eq(true)
+  })
+
+  it("handles failed get calls", async () => {
+    const k = `cache-test${Math.random()}`
+
+    await cache.set(k, new ArrayBuffer(0))
+
+    const result = await cache.get(k)
+    expect(result).to.eq(null)
+  })
 })


### PR DESCRIPTION
This branch handles bad cache data much better, empty arraybuffers work now, and it won't error on string decoding or if the underlying store fails on get.