### PR TITLE
feat: glob support for files array

### DIFF
--- a/src/bridge/fetch.ts
+++ b/src/bridge/fetch.ts
@@ -9,6 +9,7 @@ import { parse as parseURL } from 'url'
 import { Bridge } from './bridge';
 import { Runtime } from '../runtime';
 import { streamManager } from '../stream_manager';
+import { makeRe } from 'minimatch';
 
 const fetchAgent = new http.Agent({
   keepAlive: true,
@@ -22,6 +23,15 @@ const fetchHttpsAgent = new https.Agent({
   maxSockets: 1024 * 10 // seems sensible
 })
 
+function makeResponse(status: number, statusText: string, url: string, headers?: any) {
+  return {
+    status: status,
+    statusText: statusText,
+    ok: (status >= 200 && status < 300),
+    url: url,
+    headers: headers || {}
+  }
+}
 registerBridge('fetch', function fetchBridge(rt: Runtime, bridge: Bridge, urlStr: string, init: any, body: ArrayBuffer | null | string, cb: ivm.Reference<Function>) {
   log.debug("native fetch with url:", urlStr)
   init || (init = {})
@@ -34,7 +44,9 @@ registerBridge('fetch', function fetchBridge(rt: Runtime, bridge: Bridge, urlStr
     }
 
     if (init.method && init.method != 'GET') {
-      cb.applyIgnored(null, ["only GET allowed on file:// URIs"])
+      cb.applyIgnored(null, [null,
+        makeResponse(405, "Method Not Allowed", urlStr)
+      ])
       return
     }
 
@@ -42,21 +54,21 @@ registerBridge('fetch', function fetchBridge(rt: Runtime, bridge: Bridge, urlStr
       bridge.fileStore.createReadStream(rt, urlStr.replace("file://", "")).then((stream) => {
         const id = streamManager.addPrefixed(rt, stream)
         cb.applyIgnored(null, [null,
-          new ivm.ExternalCopy({
-            status: 200,
-            statusText: "OK",
-            ok: true,
-            url: urlStr,
-            headers: {}
-          }).copyInto({ release: true }),
+          new ivm.ExternalCopy(makeResponse(200, "OK", urlStr)).copyInto({ release: true }),
           id
         ])
       }).catch((err) => {
-        cb.applyIgnored(null, [err.toString()])
+        cb.applyIgnored(null, [null,
+          new ivm.ExternalCopy(makeResponse(404, "Not Found", urlStr)).copyInto({ release: true }),
+          ""
+        ])
       })
     } catch (e) {
       // Might throw FileNotFound
-      cb.applyIgnored(null, [e.toString()])
+      cb.applyIgnored(null, [null,
+        new ivm.ExternalCopy(makeResponse(404, "Not Found", urlStr)).copyInto({ release: true }),
+        ""
+      ])
     }
     return
   }

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -36,9 +36,11 @@ const deploy = root
     const release = getLocalRelease(cwd, env, { noWatch: true })
 
     buildApp(cwd, { watch: false, uglify: true }, async (err: Error, source: string, hash: string, sourceMap: string) => {
+      // look for generated config
+      const configPath = existsSync(pathResolve(".fly", ".fly.yml")) ? ".fly/.fly.yml" : ".fly.yml"
       try {
         const entries = [
-          ".fly/.fly.yml", // processed .fly.yml
+          configPath, // processed .fly.yml
           ...glob.sync('.fly/*/**.{js,json}', { cwd: cwd }),
           ...release.files
         ].filter((f) => existsSync(pathResolve(cwd, f)))

--- a/src/utils/local.ts
+++ b/src/utils/local.ts
@@ -99,7 +99,12 @@ export class LocalRelease extends EventEmitter implements Release {
     const files = config.files
     config.files = []
 
-    for (const p of files) {
+    for (let p of files) {
+      const stat = fs.statSync(path.join(this.cwd, p))
+      if (stat.isDirectory) {
+        // glob full directories by default
+        p = path.join(p, "**")
+      }
       for (const f of glob.sync(p, { cwd: this.cwd })) {
         if (f !== p) dirty = true // at least one glob
         config.files.push(f)

--- a/src/utils/local.ts
+++ b/src/utils/local.ts
@@ -100,10 +100,12 @@ export class LocalRelease extends EventEmitter implements Release {
     config.files = []
 
     for (let p of files) {
-      const stat = fs.statSync(path.join(this.cwd, p))
-      if (stat.isDirectory) {
-        // glob full directories by default
-        p = path.join(p, "**")
+      if (fs.existsSync(p)) {
+        const stat = fs.statSync(path.join(this.cwd, p))
+        if (stat.isDirectory()) {
+          // glob full directories by default
+          p = path.join(p, "**")
+        }
       }
       for (const f of glob.sync(p, { cwd: this.cwd })) {
         if (f !== p) dirty = true // at least one glob

--- a/test/fixtures/apps/files/.fly.yml
+++ b/test/fixtures/apps/files/.fly.yml
@@ -1,3 +1,4 @@
 app: got-files
 files:
   - dummy.txt
+  - no-file-dummy.txt

--- a/test/fixtures/apps/files/index.js
+++ b/test/fixtures/apps/files/index.js
@@ -1,3 +1,13 @@
-addEventListener('fetch', function (event) {
-  event.respondWith(fetch("file://dummy.txt"))
+fly.http.respondWith(async function (req) {
+  const good = await fetch("file://dummy.txt")
+  const bad = await fetch("file://no-file-dummy.txt")
+
+  if (bad.status != 404) {
+    return new Response(`Wrong status when not found: ${bad.status}`, { status: 500 })
+  }
+  if (good.status != 200) {
+    return new Response(`Wrong status when found: ${good.status}`, { status: 500 })
+  }
+
+  return good
 })


### PR DESCRIPTION
This adds glob support for the `files` array in `.fly.yml`. When `.fly.yml` is loaded, it expands any globs in the array and writes a generated `.fly.yml` to the build dir, which is then renamed when tar happens.