### PR TITLE
Include app url in deploy output

### DIFF
--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -83,7 +83,8 @@ const deploy = root
         })
 
         processResponse(res, (res: any) => {
-          console.log(`Deploying v${res.data.data.attributes.version} globally, should be updated in a few seconds.`)
+          console.log(`Deploying v${res.data.data.attributes.version} globally @ https://${appName}.edgeapp.net`)
+          console.log(`App should be updated in a few seconds.`)
         })
 
       } catch (e) {


### PR DESCRIPTION
```
Deploying muddy-feather-3181 (env: production)
Generating Webpack config...
Compiling app w/ options: { watch: false, uglify: true }
Compiled app bundle (hash: 7bbb89de13a60a5f7c502d25621af7a520460f28)
Bundle size: 0.02685546875MB
Bundle compressed size: 0.008243560791015625MB
Deploying v11 globally @ https://muddy-feather-3181.edgeapp.net
App should be updated in a few seconds.
```