### PR TITLE
feat: timeout option on fetch

### DIFF
--- a/test/fixtures/apps/basic-fetch-and-read.js
+++ b/test/fixtures/apps/basic-fetch-and-read.js
@@ -1,6 +1,19 @@
 fly.http.respondWith(async function (req) {
-  let resp = await fetch("https://example.com")
-  let txt = await resp.text()
-  console.log("Got text length:", txt.length)
-  return new Response(txt, resp)
+  let url = new URL(req.url)
+
+  let opts = {}
+
+  if (req.headers.get("timeout")) {
+    opts['timeout'] = parseInt(req.headers.get("timeout"))
+  }
+  try {
+    let resp = await fetch("https://example.com", opts)
+    let txt = await resp.text()
+    console.log("Got text length:", txt.length)
+    return new Response(txt, resp)
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      return new Response("timeout", { status: 502 })
+    }
+  }
 })

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -87,6 +87,29 @@ describe('Server', function () {
       // expect(res.headers['content-type']).to.equal('text/html')
     })
   })
+  describe("fetch with timeout", function () {
+    before(startServer('basic-fetch-and-read.js'))
+    after(stopServer)
+
+    before(() => {
+      // this.timeout(5000)
+      nock('https://example.com')
+        .get('/')
+        .delay({
+          head: 500,
+          body: 2000
+        })
+        .socketDelay(1000)
+        .replyWithFile(200, __dirname + "/fixtures/http/fake.js", {
+          'Content-Type': 'application/javascript'
+        })
+    })
+    it('errors on timeout', async () => {
+      let res = await axios.get("http://127.0.0.1:3333/", { headers: { host: "test", timeout: "100" } })
+      expect(res.status).to.equal(502)
+      expect(res.data).to.equal("timeout")
+    })
+  })
 
   describe('fetch read body after readTimeout', function () {
     before(startServer('fetch-read-timeout.js'))

--- a/v8env/index.js
+++ b/v8env/index.js
@@ -49,7 +49,7 @@ global.bootstrap = function bootstrap() {
 		TextEncoder, TextDecoder,
 		Headers, Request, Response, fetch, Body,
 		Blob, FormData, URL, URLSearchParams,
-		cache, crypto,
+		cache, crypto, TimeoutError,
 		MiddlewareChain // ugh
 	})
 
@@ -76,3 +76,5 @@ global.bootstrap = function bootstrap() {
 		})
 	}
 }
+
+class TimeoutError extends Error { }


### PR DESCRIPTION
The timeout option causes fetch to raise an exception when a request takes more than the specified number of milliseconds.

```javascript
const resp = await fetch(url, { timeout: 100 })
```

Things to look at:

* `timeout` is a nonstandard option on fetch. Should we specify it differently?
* This is implemented as a [`setTimeout`](https://github.com/superfly/fly/pull/113/files#diff-527f81a3f66ab0da1d61e7b7ed59fa4dR90) in node, which I think is getting [cleaned up well](https://github.com/superfly/fly/pull/113/files#diff-527f81a3f66ab0da1d61e7b7ed59fa4dR137). Node's timeout options are kind of janky, so there's no way to give it an absolute timeout otherwise.