### PR TITLE
[WIP] CLI app generator

### DIFF
--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -2,6 +2,7 @@
 
 import { root } from './root';
 
+require("./new");
 require("./apps");
 require("./orgs");
 require("./deploy");

--- a/src/cmd/new.ts
+++ b/src/cmd/new.ts
@@ -1,0 +1,79 @@
+import { root, CommonOptions, addCommonOptions, getAppName } from "./root"
+import * as path from "path"
+import * as fs from "fs"
+import { sync as glob } from "glob"
+
+export interface NewOptions {
+    template: string[]
+}
+export interface NewArgs {
+    name: string
+}
+
+const newCommand = root
+    .subCommand<NewOptions, NewArgs>("new <name>")
+    .description("Create a new Fly app.")
+    .option("-t, --template [template]", "Name of the template to use. default: javascript-app", "javascript-app")
+    .action((options, args) => {
+        const templateName = options.template[0]
+        const cwd = process.cwd()
+
+        generate({
+            cwd: cwd,
+            appName: args.name,
+            rootDir: path.resolve(cwd, args.name),
+            templateName: templateName,
+            templatePath: getTemplatePath(templateName)
+        })
+    })
+
+interface GeneratorOptions {
+    cwd: string,
+    appName: string
+    rootDir: string,
+    templateName: string,
+    templatePath: string
+}
+
+function getTemplatePath(templateName: string): string {
+    return path.resolve(__dirname, "..", "..", "templates", templateName)
+}
+
+export class GeneratorError extends Error { }
+
+function generate(options: GeneratorOptions) {
+    checkTemplate(options)
+
+    console.log(`Using template ${options.templateName}`)
+
+    console.log(`Creating project in ${options.rootDir}...`)
+    createOutputDirectory(options)
+    copyTemplateToOutput(options)
+
+    console.log(`Successfully created project ${options.appName}`)
+    console.log(`Get started with the following commands:`)
+    console.log(`  $ cd ${path.relative(options.cwd, options.rootDir)}`)
+    console.log(`  $ fly server`)
+}
+
+function checkTemplate(options: GeneratorOptions) {
+    if (!fs.existsSync(options.templatePath)) {
+        throw new GeneratorError(`Invalid template '${options.templateName}'`)
+    }
+}
+
+function createOutputDirectory(options: GeneratorOptions) {
+    fs.mkdirSync(options.rootDir)
+}
+
+function copyTemplateToOutput(options: GeneratorOptions) {
+    glob(path.join(options.templatePath, "**", "*")).forEach(inputPath => {
+        const outputPath = translateOutputPath(inputPath, options)
+        fs.copyFileSync(inputPath, outputPath)
+    })
+}
+
+function translateOutputPath(templateFile: string, options: GeneratorOptions): string {
+    var templateRelativePath = path.relative(options.templatePath, templateFile)
+    return path.join(options.rootDir, templateRelativePath)
+}

--- a/templates/javascript-app/Readme.md
+++ b/templates/javascript-app/Readme.md
@@ -1,0 +1,1 @@
+# Welcome!

--- a/templates/javascript-app/index.js
+++ b/templates/javascript-app/index.js
@@ -1,0 +1,3 @@
+fly.http.respondWith(function (request) {
+    return new Response("Time to fly!", { status: 200 })
+})

--- a/templates/javascript-app/package.json
+++ b/templates/javascript-app/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "appName",
+    "version": "0.1.0",
+    "scripts": {
+        "serve": "fly serve",
+        "deploy": "fly deploy"
+    },
+    "dependencies": {}
+}


### PR DESCRIPTION
This adds a simple command (`fly new <app-name>`) to scaffold fly edge apps from [templates](https://github.com/superfly/fly/tree/cli-new-command/templates). 

![demo](https://user-images.githubusercontent.com/5628/42846287-1c07e298-89de-11e8-90c8-ea8e3319233d.gif)

## TODO
- [ ] Better error handling for invalid arguments. Currently prints a stack trace but that really needs to be a friendly message along with command help or it'll feel like the cli broke.
- [ ] Configure `.fly.yml`, `package.json`, `tsconfig.json`, etc...
- [ ] install packages after creating the app
- [ ] Add a gitignore file

## Open Questions
- I'm going to start with simple javascript + typescript templates. Should we add anything else?
- Should examples be templates?
- Should the app name be used to configure the name in `.fly.yml`? If so we need to gracefully resolve conflict so users aren't prevented from deploying after running `fly new test`
- Any reason for the `new` command to not be listed first in output of `fly`?

Closes #85 