### PR TITLE
Add useDots for jest-silent-reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,9 @@ if (process.env.CI) {
       ["jest-junit", {
         "output": "./artifacts/packages.junit.xml"
       }],
-      "jest-silent-reporter",
+      ["jest-silent-reporter", {
+        "useDots": true
+      }]
     ]
   })
 }

--- a/tests/edge-apps/jest.config.js
+++ b/tests/edge-apps/jest.config.js
@@ -11,7 +11,9 @@ if (process.env.CI) {
       ["jest-junit", {
         "output": "../../artifacts/edge-apps.junit.xml"
       }],
-      "jest-silent-reporter"
+      ["jest-silent-reporter", {
+        "useDots": true
+      }]
     ]
   })
 }


### PR DESCRIPTION
## Overview

This PR adds the new `useDots` option for jest-silent-reporter so that CI will not timeout