### PR TITLE
Files in inner package.json will strip their dependent files. 

### DIFF
--- a/examples/load-balancer/package.json
+++ b/examples/load-balancer/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "Apache-2.0",
   "main": "lib/balancer.js",
-  "files": [
-    "lib/*"
-  ],
+  // "files": [
+  //   "lib/*"
+  // ],
   "devDependencies": {
     "@fly/fly": "^0.38.0",
     "@types/chai": "^4.1.4",

--- a/examples/rate-limiter/package.json
+++ b/examples/rate-limiter/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "ISC",
   "main": "lib/index.js",
-  "files": [
-    "lib/*"
-  ],
+  // "files": [
+  //   "lib/*"
+  // ],
   "devDependencies": {
     "typescript": "^2.9.2"
   },


### PR DESCRIPTION
Having inner `package.json`s with `files` specified effectively means it ignores non-listed items. This means that these two examples were excluding their prebuilt code (because of how they're configured). 

This is probably not a real fix considering there are other default things ignored, but perhaps that doesn't matter. To restore the template functionality for now, I'd recommend commenting them out. For future I can think of a few options:

* Use "real" code generation tools
* At build time strip things like `files` from the `apps` dir that's a copy of `examples`
* Script packing the code to a tar and publish that rather than what `npm pack` does

Docs: https://docs.npmjs.com/files/package.json#files

Addressing #182 