### PR TITLE
fix(v8env): replace URL parsing dependency

### DIFF
--- a/packages/v8env/package.json
+++ b/packages/v8env/package.json
@@ -30,7 +30,7 @@
         "eventemitter2": "^5.0.1",
         "htmlparser2": "^3.9.2",
         "http-cache-semantics": "^3.8.1",
-        "universal-url-lite": "^1.0.0"
+        "whatwg-url": "^7.0.0"
     },
     "devDependencies": {
         "@types/cookie": "^0.3.1",

--- a/packages/v8env/src/index.ts
+++ b/packages/v8env/src/index.ts
@@ -12,7 +12,7 @@ import { ReadableStream, WritableStream, TransformStream } from "./streams"
 import { console } from "./console"
 import flyInit from "./fly/index"
 
-import { URL, URLSearchParams } from "universal-url-lite" // 'whatwg-url'
+import { URL, URLSearchParams } from "whatwg-url"
 import { Headers } from "./headers"
 
 import { TextEncoder, TextDecoder } from "./text-encoding"


### PR DESCRIPTION
Use `whatwg-url` so installing in a project that uses Babel 7 or higher
works.

Closes #191