### PR TITLE
Update @fly/v8env to 0.44.1

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -18,7 +18,7 @@
         "build:watch": "tsc -b -w -v ."
     },
     "dependencies": {
-        "@fly/v8env": "0.42.2",
+        "@fly/v8env": "0.44.1",
         "uglifyjs-webpack-plugin": "^1.3.0",
         "webpack": "^3.11.0"
     },


### PR DESCRIPTION
So the last merged changes also work for `@fly/build`.

:spiral_notepad: Sitenote, I would bump all packages to version 1 to follow semver in combination with lerna independent mode and use version ranges for internal packages too, these kind of changes won't be needed for non-breaking version bumps.